### PR TITLE
refactor: rename trigger to detector

### DIFF
--- a/Classes/Detector/DetectorInterface.php
+++ b/Classes/Detector/DetectorInterface.php
@@ -19,17 +19,17 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace MoveElevator\Typo3LoginWarning\Trigger;
+namespace MoveElevator\Typo3LoginWarning\Detector;
 
 use TYPO3\CMS\Core\Authentication\AbstractUserAuthentication;
 
 /**
- * TriggerInterface.
+ * DetectorInterface.
  *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0
  */
-interface TriggerInterface
+interface DetectorInterface
 {
-    public function isTriggered(AbstractUserAuthentication $user, array $configuration = []): bool;
+    public function detect(AbstractUserAuthentication $user, array $configuration = []): bool;
 }

--- a/Classes/Detector/NewIpDetector.php
+++ b/Classes/Detector/NewIpDetector.php
@@ -19,7 +19,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace MoveElevator\Typo3LoginWarning\Trigger;
+namespace MoveElevator\Typo3LoginWarning\Detector;
 
 use Doctrine\DBAL\Exception;
 use MoveElevator\Typo3LoginWarning\Domain\Repository\IpLogRepository;
@@ -28,12 +28,12 @@ use TYPO3\CMS\Core\Authentication\AbstractUserAuthentication;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * NewIp.
+ * NewIpDetector.
  *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0
  */
-class NewIp implements TriggerInterface
+class NewIpDetector implements DetectorInterface
 {
     private ?array $locationData = null;
 
@@ -45,7 +45,7 @@ class NewIp implements TriggerInterface
     /**
      * @throws Exception
      */
-    public function isTriggered(AbstractUserAuthentication $user, array $configuration = []): bool
+    public function detect(AbstractUserAuthentication $user, array $configuration = []): bool
     {
         $userArray = $user->user;
         if (

--- a/README.md
+++ b/README.md
@@ -45,22 +45,22 @@ Download the zip file from [TYPO3 extension repository (TER)](https://extensions
 
 ## 🧰 Configuration
 
-Add a warning trigger in your `ext_localconf.php`:
+Add a warning detector in your `ext_localconf.php`:
 
 ```php
 use MoveElevator\Typo3LoginWarning\Configuration;
 use MoveElevator\Typo3LoginWarning\Notification\EmailNotification;
-use MoveElevator\Typo3LoginWarning\Trigger\NewIp;
+use MoveElevator\Typo3LoginWarning\Detector\NewIpDetector;
 
 // Simple configuration
 // (EmailNotification will be used with "warning_email_addr" configuration)
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['trigger'] = [
-    NewIp::class
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['detector'] = [
+    NewIpDetector::class
 ];
 
 // Extended example configuration 
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['trigger'] = [
-    NewIp::class => [
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['detector'] = [
+    NewIpDetector::class => [
         'hashIpAddress' => false,
         'fetchGeolocation' => false,
         'whitelist' => [
@@ -77,18 +77,18 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['trigger'] = [
 
 ## 💡 Concepts
 
-### Trigger
+### Detectors
 
-Triggers are used to detect certain login events. If a trigger matches, a notification will be sent.
+Detectors are used to detect certain login events. If a detector matches, a notification will be sent.
 
-The following triggers are available:
+The following detectors are available:
 
-- `NewIp`: Triggers a warning email if a backend user logs in from a new IP address. The IP address will be stored and can be hashed for privacy reasons. You can also define a whitelist of IP addresses that will not trigger a warning. An ip geolocation lookup can be enabled to add more information to the notification email.
+- `NewIpDetector`: Detects logins from new IP addresses and triggers a warning email. The IP address will be stored and can be hashed for privacy reasons. You can also define a whitelist of IP addresses that will not trigger a warning. An ip geolocation lookup can be enabled to add more information to the notification email.
 
 ![email.jpg](Documentation/Images/email.jpg)
 
 > [!TIP]
-> You can implement your own trigger by implementing the `MoveElevator\Typo3LoginWarning\Trigger\TriggerInterface`.
+> You can implement your own detector by implementing the `MoveElevator\Typo3LoginWarning\Detector\DetectorInterface`.
 
 ### Notification
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -20,14 +20,14 @@
  */
 
 use MoveElevator\Typo3LoginWarning\Configuration;
+use MoveElevator\Typo3LoginWarning\Detector\NewIpDetector;
 use MoveElevator\Typo3LoginWarning\Notification\EmailNotification;
-use MoveElevator\Typo3LoginWarning\Trigger\NewIp;
 
 $GLOBALS['TYPO3_CONF_VARS']['MAIL']['templateRootPaths'][500] = 'EXT:' . Configuration::EXT_KEY . '/Resources/Private/Templates/Email';
 
-// default configuration for triggers
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['_trigger'] = [
-    NewIp::class => [
+// default configuration for detectors
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['_detector'] = [
+    NewIpDetector::class => [
         'hashIpAddress' => true,
         'fetchGeolocation' => true,
         'whitelist' => [],
@@ -41,4 +41,4 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['_notification'] 
     ],
 ];
 
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['trigger'] = [];
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['detector'] = [];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Renamed “Trigger” concept to “Detector” across the app, including public APIs, logs, and configuration structure.
  - Configuration keys changed from trigger/_trigger to detector/_detector. Update your configuration accordingly.

- Documentation
  - Updated README and examples to use the new “Detector” terminology and configuration format.

- Tests
  - Updated unit tests to reflect the new detector-based flow.

- Chores
  - Adjusted default configuration to use detectors, ensuring consistent behavior with the new terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->