### PR TITLE
fix: include geolocation information in new IP login notifications

### DIFF
--- a/Resources/Private/Templates/Email/Default/LoginNotification/NewIpDetector.html
+++ b/Resources/Private/Templates/Email/Default/LoginNotification/NewIpDetector.html
@@ -1,23 +1,23 @@
 <f:layout name="SystemEmail" />
-<f:variable name="locationInfo">
-    <f:spaceless>
-        <f:if condition="{locationData} && {locationData.city} && {locationData.country}">
-            <f:then>
-                ({locationData.city}, {locationData.country})
-            </f:then>
-        </f:if>
-    </f:spaceless>
-</f:variable>
 <f:section name="Subject">{prefix} Login at "{typo3.sitename}" from new IP address</f:section>
 <f:section name="Title">{headline}</f:section>
 <f:section name="Main">
     <h4>{introduction}</h4>
+    <f:variable name="locationInfo">
+        <f:spaceless>
+            <f:if condition="{locationData} && {locationData.city} && {locationData.country}">
+                <f:then>
+                    ({locationData.city}, {locationData.country})
+                </f:then>
+            </f:if>
+        </f:spaceless>
+    </f:variable>
     <f:if condition="{isUserNotification}">
         <f:then>
-            <p>You logged in from a new IP address <code>{normalizedParams.remoteAddress}</code>{locationInfo} at the site "{typo3.sitename}".</p>
+            <p>You logged in from a <strong>new IP address</strong> <code>{normalizedParams.remoteAddress}</code>{locationInfo} at the site "{typo3.sitename}".</p>
         </f:then>
         <f:else>
-            <p>The user <em>"{user.username}"</em> logged in from a new IP address <code>{normalizedParams.remoteAddress}</code>{locationInfo} at the site "{typo3.sitename}".</p>
+            <p>The user <em>"{user.username}"</em> logged in from a <strong>new IP address</strong> <code>{normalizedParams.remoteAddress}</code>{locationInfo} at the site "{typo3.sitename}".</p>
         </f:else>
     </f:if>
 </f:section>

--- a/Resources/Private/Templates/Email/Default/LoginNotification/NewIpDetector.txt
+++ b/Resources/Private/Templates/Email/Default/LoginNotification/NewIpDetector.txt
@@ -1,16 +1,10 @@
 <f:layout name="SystemEmail" />
-<f:variable name="locationInfo">
-    <f:spaceless>
-        <f:if condition="{locationData} && {locationData.city} && {locationData.country}">
-            <f:then>
-                ({locationData.city}, {locationData.country})
-            </f:then>
-        </f:if>
-    </f:spaceless>
-</f:variable>
 <f:section name="Subject">{prefix} Login at "{typo3.sitename}" from new IP address</f:section>
 <f:section name="Title">{headline}</f:section>
 <f:section name="Main">{introduction}
+<f:variable name="locationInfo"><f:spaceless>
+<f:if condition="{locationData} && {locationData.city} && {locationData.country}"><f:then>({locationData.city}, {locationData.country})</f:then></f:if></f:spaceless>
+</f:variable>
 <f:if condition="{isUserNotification}">
 <f:then>You logged in from a new IP address "{normalizedParams.remoteAddress}"{locationInfo} at the site "{typo3.sitename}".</f:then>
 <f:else>The user "{user.username}" logged in from a new IP address "{normalizedParams.remoteAddress}"{locationInfo} at the site "{typo3.sitename}".</f:else>

--- a/Tests/Acceptance/Fixtures/packages/sitepackage/ext_localconf.php
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/ext_localconf.php
@@ -32,7 +32,7 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['warning_email_addr'] = 'test456@test.de';
 // NewIp Detector with specific configuration for testing
 LoginWarning::newIp([
     'hashIpAddress' => true,
-    'fetchGeolocation' => false,
+    'fetchGeolocation' => true,
     'whitelist' => [], // No whitelist for testing
     'notification' => [
         EmailNotification::class => [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - HTML login notification emails now emphasize “new IP address” and display location details after the introduction for improved readability.
- Refactor
  - Plain-text login notification template streamlined for constructing location details without changing the displayed content.
- Tests
  - Enabled geolocation fetching in acceptance tests to validate location information in emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->