### PR TITLE
feat: replace 'onlyAdmins' and 'onlySystemMaintainers' with 'affectedUsers' and 'notificationReceiver' in configuration

### DIFF
--- a/Classes/Configuration/DetectorConfigurationBuilder.php
+++ b/Classes/Configuration/DetectorConfigurationBuilder.php
@@ -100,7 +100,6 @@ final class DetectorConfigurationBuilder implements LoggerAwareInterface
         $extensionConfiguration = $this->getExtensionConfiguration();
         return [
             'recipient' => $extensionConfiguration['notificationRecipients'] ?? $GLOBALS['TYPO3_CONF_VARS']['BE']['warning_email_addr'] ?? '',
-            'notifyUser' => (bool)($extensionConfiguration['notifyUser'] ?? false),
         ];
     }
 
@@ -131,8 +130,8 @@ final class DetectorConfigurationBuilder implements LoggerAwareInterface
         return [
             'hashIpAddress' => (bool)($config['hashIpAddress'] ?? true),
             'fetchGeolocation' => (bool)($config['fetchGeolocation'] ?? true),
-            'onlyAdmins' => (bool)($config['onlyAdmins'] ?? false),
-            'onlySystemMaintainers' => (bool)($config['onlySystemMaintainers'] ?? false),
+            'affectedUsers' => $config['affectedUsers'] ?? 'all',
+            'notificationReceiver' => $config['notificationReceiver'] ?? 'recipients',
             'whitelist' => $this->parseCommaSeparatedList($config['whitelist'] ?? '127.0.0.1'),
         ];
     }
@@ -145,8 +144,8 @@ final class DetectorConfigurationBuilder implements LoggerAwareInterface
     {
         return [
             'thresholdDays' => (int)($config['thresholdDays'] ?? 365),
-            'onlyAdmins' => (bool)($config['onlyAdmins'] ?? false),
-            'onlySystemMaintainers' => (bool)($config['onlySystemMaintainers'] ?? false),
+            'affectedUsers' => $config['affectedUsers'] ?? 'all',
+            'notificationReceiver' => $config['notificationReceiver'] ?? 'recipients',
         ];
     }
 
@@ -158,8 +157,8 @@ final class DetectorConfigurationBuilder implements LoggerAwareInterface
     {
         $result = [
             'timezone' => $config['timezone'] ?? $GLOBALS['TYPO3_CONF_VARS']['SYS']['phpTimeZone'] ?? 'UTC',
-            'onlyAdmins' => (bool)($config['onlyAdmins'] ?? false),
-            'onlySystemMaintainers' => (bool)($config['onlySystemMaintainers'] ?? false),
+            'affectedUsers' => $config['affectedUsers'] ?? 'all',
+            'notificationReceiver' => $config['notificationReceiver'] ?? 'recipients',
         ];
 
         // Parse working hours JSON

--- a/Classes/Detector/AbstractDetector.php
+++ b/Classes/Detector/AbstractDetector.php
@@ -39,25 +39,12 @@ abstract class AbstractDetector implements DetectorInterface
     protected function shouldDetectForUser(AbstractUserAuthentication $user, array $configuration): bool
     {
         $userArray = $user->user;
+        $affectedUsers = $configuration['affectedUsers'] ?? 'all';
 
-        // Check if detection should only apply to admins
-        if (
-            array_key_exists('onlyAdmins', $configuration) &&
-            $configuration['onlyAdmins'] === true &&
-            !($userArray['admin'] ?? false)
-        ) {
-            return false;
-        }
-
-        // Check if detection should only apply to system maintainers
-        if (
-            array_key_exists('onlySystemMaintainers', $configuration) &&
-            $configuration['onlySystemMaintainers'] === true &&
-            !in_array((int)$userArray['uid'], $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] ?? [], true)
-        ) {
-            return false;
-        }
-
-        return true;
+        return match ($affectedUsers) {
+            'admins' => (bool)($userArray['admin'] ?? false),
+            'maintainers' => in_array((int)$userArray['uid'], $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] ?? [], true),
+            default => true, // 'all'
+        };
     }
 }

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ The IP address will be stored and can be hashed for privacy reasons. You can als
 | **Hash IP Addresses** | Hash IP addresses for privacy (SHA-256) | `true`      |
 | **Fetch Geolocation** | Enable IP geolocation lookup | `true`      |
 | **IP Whitelist** | Comma-separated list of whitelisted IPs/networks (supports CIDR notation like `192.168.1.0/24`) | `127.0.0.1` |
-| **Only Admins** | Only detect for admin users | `false`     |
-| **Only System Maintainers** | Only detect for system maintainers | `false`     |
+| **Affected Users** | Which users should trigger this detector: `All Users`, `Only Admins`, `Only System Maintainers` | `All Users` |
+| **Notification Receiver** | Who should receive the notification: `Email Recipients`, `Logged-In User`, `Both` | `Email Recipients` |
 
 ##### Geolocation
 
@@ -119,8 +119,8 @@ Detects logins after a long period of inactivity (default: 365 days).
 |---------|-------------|---------|
 | **Active** | Enable Long Time No See detector | `true` |
 | **Threshold Days** | Days of inactivity before triggering | `365` |
-| **Only Admins** | Only detect for admin users | `false` |
-| **Only System Maintainers** | Only detect for system maintainers | `false` |
+| **Affected Users** | Which users should trigger this detector: `All Users`, `Only Admins`, `Only System Maintainers` | `All Users` |
+| **Notification Receiver** | Who should receive the notification: `Email Recipients`, `Logged-In User`, `Both` | `Email Recipients` |
 
 #### [OutOfOfficeDetector](Classes/Detector/OutOfOfficeDetector.php)
 
@@ -137,8 +137,8 @@ Detects logins outside defined working hours, holidays, or vacation periods. Sup
 | **Timezone** | Timezone for working hours | `UTC`                          |
 | **Holidays** | Comma-separated list of holidays in Y-m-d format (e.g., `2025-01-01,2025-12-25`) | Empty                          |
 | **Vacation Periods** | Comma-separated vacation periods in start:end format (e.g., `2025-07-15:2025-07-30,2025-12-20:2025-12-31`) | Empty                          |
-| **Only Admins** | Only detect for admin users | `false`                        |
-| **Only System Maintainers** | Only detect for system maintainers | `false`                        |
+| **Affected Users** | Which users should trigger this detector: `All Users`, `Only Admins`, `Only System Maintainers` | `All Users` |
+| **Notification Receiver** | Who should receive the notification: `Email Recipients`, `Logged-In User`, `Both` | `Email Recipients` |
 
 **Working Hours JSON Example:**
 ```json
@@ -159,9 +159,15 @@ The following notification methods are available:
 
 Sends a warning email to defined recipients. If no recipient is defined, the email will be sent to the address defined in `$GLOBALS['TYPO3_CONF_VARS']['BE']['warning_email_addr']`.
 
-**Configuration Options:**
+**Global Configuration Options:**
 - **Email Recipients**: Email address(es) of the notification recipients (comma-separated)
-- **Notify User**: When enabled, the logged-in user will also receive a notification email (requires user to have a valid email address)
+
+**Per-Detector Configuration:**
+
+Each detector has its own **Notification Receiver** setting that controls who receives notifications:
+- **Email Recipients** (default): Send notification only to configured email recipients
+- **Logged-In User**: Send notification only to the logged-in user (requires valid email address)
+- **Both**: Send notification to both email recipients and logged-in user
 
 ![email.jpg](Documentation/Images/email.jpg)
 

--- a/Tests/Unit/Configuration/DetectorConfigurationBuilderTest.php
+++ b/Tests/Unit/Configuration/DetectorConfigurationBuilderTest.php
@@ -87,8 +87,8 @@ final class DetectorConfigurationBuilderTest extends TestCase
         self::assertSame([
             'hashIpAddress' => true,
             'fetchGeolocation' => true,
-            'onlyAdmins' => false,
-            'onlySystemMaintainers' => false,
+            'affectedUsers' => 'all',
+            'notificationReceiver' => 'recipients',
             'whitelist' => ['127.0.0.1'],
         ], $result);
     }
@@ -100,7 +100,8 @@ final class DetectorConfigurationBuilderTest extends TestCase
                 'active' => true,
                 'hashIpAddress' => false,
                 'fetchGeolocation' => false,
-                'onlyAdmins' => true,
+                'affectedUsers' => 'admins',
+                'notificationReceiver' => 'both',
                 'whitelist' => '192.168.1.1, 10.0.0.1',
             ],
         ];
@@ -110,8 +111,8 @@ final class DetectorConfigurationBuilderTest extends TestCase
         self::assertSame([
             'hashIpAddress' => false,
             'fetchGeolocation' => false,
-            'onlyAdmins' => true,
-            'onlySystemMaintainers' => false,
+            'affectedUsers' => 'admins',
+            'notificationReceiver' => 'both',
             'whitelist' => ['192.168.1.1', '10.0.0.1'],
         ], $result);
     }
@@ -126,8 +127,8 @@ final class DetectorConfigurationBuilderTest extends TestCase
 
         self::assertSame([
             'thresholdDays' => 365,
-            'onlyAdmins' => false,
-            'onlySystemMaintainers' => false,
+            'affectedUsers' => 'all',
+            'notificationReceiver' => 'recipients',
         ], $result);
     }
 
@@ -137,7 +138,8 @@ final class DetectorConfigurationBuilderTest extends TestCase
             'longTimeNoSee' => [
                 'active' => true,
                 'thresholdDays' => 180,
-                'onlySystemMaintainers' => true,
+                'affectedUsers' => 'maintainers',
+                'notificationReceiver' => 'user',
             ],
         ];
 
@@ -145,8 +147,8 @@ final class DetectorConfigurationBuilderTest extends TestCase
 
         self::assertSame([
             'thresholdDays' => 180,
-            'onlyAdmins' => false,
-            'onlySystemMaintainers' => true,
+            'affectedUsers' => 'maintainers',
+            'notificationReceiver' => 'user',
         ], $result);
     }
 
@@ -160,8 +162,8 @@ final class DetectorConfigurationBuilderTest extends TestCase
         $result = $this->subject->build(OutOfOfficeDetector::class);
 
         self::assertSame('Europe/Berlin', $result['timezone']);
-        self::assertFalse($result['onlyAdmins']);
-        self::assertFalse($result['onlySystemMaintainers']);
+        self::assertSame('all', $result['affectedUsers']);
+        self::assertSame('recipients', $result['notificationReceiver']);
         self::assertSame([
             'monday' => ['06:00', '19:00'],
             'tuesday' => ['06:00', '19:00'],
@@ -219,20 +221,17 @@ final class DetectorConfigurationBuilderTest extends TestCase
         $result = $this->subject->buildNotificationConfig();
 
         self::assertSame('admin@example.com', $result['recipient']);
-        self::assertFalse($result['notifyUser']);
     }
 
     public function testBuildNotificationConfigWithCustomValues(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY] = [
             'notificationRecipients' => 'security@example.com',
-            'notifyUser' => true,
         ];
 
         $result = $this->subject->buildNotificationConfig();
 
         self::assertSame('security@example.com', $result['recipient']);
-        self::assertTrue($result['notifyUser']);
     }
 
     public function testGetConfigPrefixReturnsCorrectPrefix(): void

--- a/Tests/Unit/Detector/AbstractDetectorTest.php
+++ b/Tests/Unit/Detector/AbstractDetectorTest.php
@@ -76,43 +76,42 @@ final class AbstractDetectorTest extends TestCase
         self::assertTrue($this->subject->exposeShouldDetectForUser($user, []));
     }
 
-    public function testShouldDetectForUserReturnsTrueForAdminWhenOnlyAdminsEnabled(): void
+    public function testShouldDetectForUserReturnsTrueForAdminWhenAffectedUsersIsAdmins(): void
     {
         $user = $this->createMockUser(isAdmin: true);
 
-        self::assertTrue($this->subject->exposeShouldDetectForUser($user, ['onlyAdmins' => true]));
+        self::assertTrue($this->subject->exposeShouldDetectForUser($user, ['affectedUsers' => 'admins']));
     }
 
-    public function testShouldDetectForUserReturnsFalseForNonAdminWhenOnlyAdminsEnabled(): void
+    public function testShouldDetectForUserReturnsFalseForNonAdminWhenAffectedUsersIsAdmins(): void
     {
         $user = $this->createMockUser(isAdmin: false);
 
-        self::assertFalse($this->subject->exposeShouldDetectForUser($user, ['onlyAdmins' => true]));
+        self::assertFalse($this->subject->exposeShouldDetectForUser($user, ['affectedUsers' => 'admins']));
     }
 
-    public function testShouldDetectForUserReturnsTrueForSystemMaintainerWhenOnlySystemMaintainersEnabled(): void
+    public function testShouldDetectForUserReturnsTrueForSystemMaintainerWhenAffectedUsersIsMaintainers(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [1, 2];
         $user = $this->createMockUser(uid: 1);
 
-        self::assertTrue($this->subject->exposeShouldDetectForUser($user, ['onlySystemMaintainers' => true]));
+        self::assertTrue($this->subject->exposeShouldDetectForUser($user, ['affectedUsers' => 'maintainers']));
     }
 
-    public function testShouldDetectForUserReturnsFalseForNonSystemMaintainerWhenOnlySystemMaintainersEnabled(): void
+    public function testShouldDetectForUserReturnsFalseForNonSystemMaintainerWhenAffectedUsersIsMaintainers(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [2, 3];
         $user = $this->createMockUser(uid: 1);
 
-        self::assertFalse($this->subject->exposeShouldDetectForUser($user, ['onlySystemMaintainers' => true]));
+        self::assertFalse($this->subject->exposeShouldDetectForUser($user, ['affectedUsers' => 'maintainers']));
     }
 
-    public function testShouldDetectForUserReturnsTrueWhenBothRestrictionsAreDisabled(): void
+    public function testShouldDetectForUserReturnsTrueWhenAffectedUsersIsAll(): void
     {
         $user = $this->createMockUser(isAdmin: false);
 
         self::assertTrue($this->subject->exposeShouldDetectForUser($user, [
-            'onlyAdmins' => false,
-            'onlySystemMaintainers' => false,
+            'affectedUsers' => 'all',
         ]));
     }
 }

--- a/Tests/Unit/Detector/LongTimeNoSeeDetectorTest.php
+++ b/Tests/Unit/Detector/LongTimeNoSeeDetectorTest.php
@@ -400,11 +400,11 @@ final class LongTimeNoSeeDetectorTest extends TestCase
         self::assertLessThan(740, $days);
     }
 
-    public function testDetectReturnsFalseForNonAdminWhenOnlyAdminsEnabled(): void
+    public function testDetectReturnsFalseForNonAdminWhenAffectedUsersIsAdmins(): void
     {
         $user = $this->createMockUser(['uid' => 123, 'admin' => false]);
         $configuration = [
-            'onlyAdmins' => true,
+            'affectedUsers' => 'admins',
         ];
 
         $this->userLogRepository->expects(self::never())->method('getLastLoginCheckTimestamp');
@@ -415,12 +415,12 @@ final class LongTimeNoSeeDetectorTest extends TestCase
         self::assertFalse($result);
     }
 
-    public function testDetectReturnsTrueForAdminWhenOnlyAdminsEnabled(): void
+    public function testDetectReturnsTrueForAdminWhenAffectedUsersIsAdmins(): void
     {
         $user = $this->createMockUser(['uid' => 123, 'admin' => true]);
         $oneYearAgo = time() - (366 * 24 * 60 * 60);
         $configuration = [
-            'onlyAdmins' => true,
+            'affectedUsers' => 'admins',
         ];
 
         $this->userLogRepository
@@ -438,13 +438,13 @@ final class LongTimeNoSeeDetectorTest extends TestCase
         self::assertTrue($result);
     }
 
-    public function testDetectReturnsFalseForNonSystemMaintainerWhenOnlySystemMaintainersEnabled(): void
+    public function testDetectReturnsFalseForNonSystemMaintainerWhenAffectedUsersIsMaintainers(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [2, 3];
 
         $user = $this->createMockUser(['uid' => 123]);
         $configuration = [
-            'onlySystemMaintainers' => true,
+            'affectedUsers' => 'maintainers',
         ];
 
         $this->userLogRepository->expects(self::never())->method('getLastLoginCheckTimestamp');
@@ -455,14 +455,14 @@ final class LongTimeNoSeeDetectorTest extends TestCase
         self::assertFalse($result);
     }
 
-    public function testDetectReturnsTrueForSystemMaintainerWhenOnlySystemMaintainersEnabled(): void
+    public function testDetectReturnsTrueForSystemMaintainerWhenAffectedUsersIsMaintainers(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [123, 456];
 
         $user = $this->createMockUser(['uid' => 123]);
         $oneYearAgo = time() - (366 * 24 * 60 * 60);
         $configuration = [
-            'onlySystemMaintainers' => true,
+            'affectedUsers' => 'maintainers',
         ];
 
         $this->userLogRepository

--- a/Tests/Unit/Detector/NewIpDetectorTest.php
+++ b/Tests/Unit/Detector/NewIpDetectorTest.php
@@ -247,11 +247,11 @@ final class NewIpDetectorTest extends TestCase
         self::assertNull($subject->getLocationData());
     }
 
-    public function testDetectReturnsFalseForNonAdminWhenOnlyAdminsEnabled(): void
+    public function testDetectReturnsFalseForNonAdminWhenAffectedUsersIsAdmins(): void
     {
         $user = $this->createMockUser(['uid' => 123, 'admin' => false]);
         $configuration = [
-            'onlyAdmins' => true,
+            'affectedUsers' => 'admins',
         ];
 
         $GLOBALS['_SERVER']['REMOTE_ADDR'] = '1.2.3.4';
@@ -265,11 +265,11 @@ final class NewIpDetectorTest extends TestCase
         self::assertFalse($result);
     }
 
-    public function testDetectReturnsTrueForAdminWhenOnlyAdminsEnabled(): void
+    public function testDetectReturnsTrueForAdminWhenAffectedUsersIsAdmins(): void
     {
         $user = $this->createMockUser(['uid' => 123, 'admin' => true]);
         $configuration = [
-            'onlyAdmins' => true,
+            'affectedUsers' => 'admins',
         ];
 
         $GLOBALS['_SERVER']['REMOTE_ADDR'] = '1.2.3.4';
@@ -286,13 +286,13 @@ final class NewIpDetectorTest extends TestCase
         self::assertTrue($result);
     }
 
-    public function testDetectReturnsFalseForNonSystemMaintainerWhenOnlySystemMaintainersEnabled(): void
+    public function testDetectReturnsFalseForNonSystemMaintainerWhenAffectedUsersIsMaintainers(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [2, 3];
 
         $user = $this->createMockUser(['uid' => 123]);
         $configuration = [
-            'onlySystemMaintainers' => true,
+            'affectedUsers' => 'maintainers',
         ];
 
         $GLOBALS['_SERVER']['REMOTE_ADDR'] = '1.2.3.4';
@@ -306,13 +306,13 @@ final class NewIpDetectorTest extends TestCase
         self::assertFalse($result);
     }
 
-    public function testDetectReturnsTrueForSystemMaintainerWhenOnlySystemMaintainersEnabled(): void
+    public function testDetectReturnsTrueForSystemMaintainerWhenAffectedUsersIsMaintainers(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [123, 456];
 
         $user = $this->createMockUser(['uid' => 123]);
         $configuration = [
-            'onlySystemMaintainers' => true,
+            'affectedUsers' => 'maintainers',
         ];
 
         $GLOBALS['_SERVER']['REMOTE_ADDR'] = '1.2.3.4';

--- a/Tests/Unit/Detector/OutOfOfficeDetectorTest.php
+++ b/Tests/Unit/Detector/OutOfOfficeDetectorTest.php
@@ -326,14 +326,14 @@ final class OutOfOfficeDetectorTest extends TestCase
         self::assertSame('vacation', $violationDetails['type']);
     }
 
-    public function testDetectReturnsFalseForNonAdminWhenOnlyAdminsEnabled(): void
+    public function testDetectReturnsFalseForNonAdminWhenAffectedUsersIsAdmins(): void
     {
         $user = $this->createMockUser(['uid' => 123, 'admin' => false]);
         $configuration = [
             'workingHours' => [
                 'monday' => ['09:00', '17:00'],
             ],
-            'onlyAdmins' => true,
+            'affectedUsers' => 'admins',
             'timezone' => 'UTC',
         ];
 
@@ -344,14 +344,14 @@ final class OutOfOfficeDetectorTest extends TestCase
         self::assertFalse($result);
     }
 
-    public function testDetectReturnsTrueForAdminWhenOnlyAdminsEnabled(): void
+    public function testDetectReturnsTrueForAdminWhenAffectedUsersIsAdmins(): void
     {
         $user = $this->createMockUser(['uid' => 123, 'admin' => true]);
         $configuration = [
             'workingHours' => [
                 'monday' => ['09:00', '17:00'],
             ],
-            'onlyAdmins' => true,
+            'affectedUsers' => 'admins',
             'timezone' => 'UTC',
         ];
 
@@ -362,7 +362,7 @@ final class OutOfOfficeDetectorTest extends TestCase
         self::assertTrue($result);
     }
 
-    public function testDetectReturnsFalseForNonSystemMaintainerWhenOnlySystemMaintainersEnabled(): void
+    public function testDetectReturnsFalseForNonSystemMaintainerWhenAffectedUsersIsMaintainers(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [2, 3];
 
@@ -371,7 +371,7 @@ final class OutOfOfficeDetectorTest extends TestCase
             'workingHours' => [
                 'monday' => ['09:00', '17:00'],
             ],
-            'onlySystemMaintainers' => true,
+            'affectedUsers' => 'maintainers',
             'timezone' => 'UTC',
         ];
 
@@ -382,7 +382,7 @@ final class OutOfOfficeDetectorTest extends TestCase
         self::assertFalse($result);
     }
 
-    public function testDetectReturnsTrueForSystemMaintainerWhenOnlySystemMaintainersEnabled(): void
+    public function testDetectReturnsTrueForSystemMaintainerWhenAffectedUsersIsMaintainers(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [123, 456];
 
@@ -391,7 +391,7 @@ final class OutOfOfficeDetectorTest extends TestCase
             'workingHours' => [
                 'monday' => ['09:00', '17:00'],
             ],
-            'onlySystemMaintainers' => true,
+            'affectedUsers' => 'maintainers',
             'timezone' => 'UTC',
         ];
 

--- a/Tests/Unit/Notification/EmailNotificationTest.php
+++ b/Tests/Unit/Notification/EmailNotificationTest.php
@@ -184,7 +184,7 @@ final class EmailNotificationTest extends TestCase
         $user = $this->createMockBackendUser(['uid' => 123, 'email' => 'user@example.com']);
         $configuration = [
             'recipient' => 'admin@example.com',
-            'notifyUser' => true,
+            'notificationReceiver' => 'both',
         ];
 
         // Expect two emails: one for admin, one for user

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -16,9 +16,6 @@ outOfOffice.active = 0
 # cat=notification/notification/010; type=string; label=Email Recipients:Email addresses for notifications (comma-separated, default is `warning_email_addr`)
 notificationRecipients =
 
-# cat=notification/notification/020; type=boolean; label=Notify User:Also send notification to the logged-in user
-notifyUser = 0
-
 # cat=newip/newip/020; type=boolean; label=Hash IP Addresses:Hash the persistence of IP addresses for privacy reasons (SHA-256)
 newIp.hashIpAddress = 1
 
@@ -28,20 +25,20 @@ newIp.fetchGeolocation = 1
 # cat=newip/newip/040; type=string; label=IP Whitelist:Comma-separated list of whitelisted IPs/networks (e.g. 127.0.0.1,192.168.1.0/24)
 newIp.whitelist = 127.0.0.1
 
-# cat=newip/newip/050; type=boolean; label=Only Admins:Only detect new IPs for admin users
-newIp.onlyAdmins = 0
+# cat=newip/newip/050; type=options[All Users=all,Only Admins=admins,Only System Maintainers=maintainers]; label=Affected Users:Which users should trigger this detector
+newIp.affectedUsers = all
 
-# cat=newip/newip/060; type=boolean; label=Only System Maintainers:Only detect new IPs for system maintainer users
-newIp.onlySystemMaintainers = 0
+# cat=newip/newip/060; type=options[Email Recipients=recipients,Logged-In User=user,Both=both]; label=Notification Receiver:Who should receive the notification
+newIp.notificationReceiver = recipients
 
 # cat=longtimenosee/longtimenosee/020; type=int+; label=Threshold Days:Days of inactivity before triggering notification
 longTimeNoSee.thresholdDays = 365
 
-# cat=longtimenosee/longtimenosee/030; type=boolean; label=Only Admins:Only detect for admin users
-longTimeNoSee.onlyAdmins = 0
+# cat=longtimenosee/longtimenosee/030; type=options[All Users=all,Only Admins=admins,Only System Maintainers=maintainers]; label=Affected Users:Which users should trigger this detector
+longTimeNoSee.affectedUsers = all
 
-# cat=longtimenosee/longtimenosee/040; type=boolean; label=Only System Maintainers:Only detect for system maintainer users
-longTimeNoSee.onlySystemMaintainers = 0
+# cat=longtimenosee/longtimenosee/040; type=options[Email Recipients=recipients,Logged-In User=user,Both=both]; label=Notification Receiver:Who should receive the notification
+longTimeNoSee.notificationReceiver = recipients
 
 # cat=outofoffice/outofoffice/020; type=string; label=Working Hours (JSON):JSON configuration for working hours (e.g. {"monday":["09:00","17:00"],"tuesday":["09:00","17:00"]})
 outOfOffice.workingHours = {"monday":["06:00","19:00"],"tuesday":["06:00","19:00"],"wednesday":["06:00","19:00"],"thursday":["06:00","19:00"],"friday":["06:00","19:00"]}
@@ -55,8 +52,8 @@ outOfOffice.holidays =
 # cat=outofoffice/outofoffice/050; type=string; label=Vacation Periods:Comma-separated list of vacation periods in Y-m-d format (e.g. 2025-07-15:2025-07-30,2025-12-20:2025-12-31)
 outOfOffice.vacationPeriods =
 
-# cat=outofoffice/outofoffice/060; type=boolean; label=Only Admins:Only detect for admin users
-outOfOffice.onlyAdmins = 0
+# cat=outofoffice/outofoffice/060; type=options[All Users=all,Only Admins=admins,Only System Maintainers=maintainers]; label=Affected Users:Which users should trigger this detector
+outOfOffice.affectedUsers = all
 
-# cat=outofoffice/outofoffice/070; type=boolean; label=Only System Maintainers:Only detect for system maintainer users
-outOfOffice.onlySystemMaintainers = 0
+# cat=outofoffice/outofoffice/070; type=options[Email Recipients=recipients,Logged-In User=user,Both=both]; label=Notification Receiver:Who should receive the notification
+outOfOffice.notificationReceiver = recipients


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced unified “Affected Users” setting (all, admins, maintainers) across detectors.
  - Added “Notification Receiver” option (recipients, user, both) to control who gets emails and user-specific flagging.
  - Updated defaults to affect all users and send to configured recipients.

- Refactor
  - Simplified detection and notification logic to honor the new settings.

- Documentation
  - Updated README and configuration template to reflect new options and defaults.

- Tests
  - Adjusted unit tests to the new configuration schema and behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->