### PR TITLE
refactor: encapsulate mail template registration in initExtLocalConfig method

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -23,4 +23,14 @@ class Configuration
 {
     final public const EXT_KEY = 'typo3_login_warning';
     final public const EXT_NAME = 'Typo3LoginWarning';
+
+    public static function initExtLocalConfig(): void
+    {
+        self::registerMailTemplate();
+    }
+
+    private static function registerMailTemplate(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['MAIL']['templateRootPaths'][500] = 'EXT:'.self::EXT_KEY.'/Resources/Private/Templates/Email';
+    }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -11,6 +11,4 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-use MoveElevator\Typo3LoginWarning\Configuration;
-
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['templateRootPaths'][500] = 'EXT:'.Configuration::EXT_KEY.'/Resources/Private/Templates/Email';
+MoveElevator\Typo3LoginWarning\Configuration::initExtLocalConfig();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Centralized initialization of email template paths into a dedicated setup flow, reducing direct global configuration and improving consistency during extension bootstrap.
  - Standardized registration of the mail template location to simplify configuration management.

- Chores
  - Streamlined startup wiring to use the new initialization entry point.
  - Minor configuration cleanup with no expected impact on user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->