### PR TITLE
build(ci): set typo3 versions to 14.3 for tests matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,5 +9,5 @@ jobs:
     uses: konradmichalik/reusable-github-actions/.github/workflows/tests-typo3.yml@main
     with:
       php-versions: '["8.2", "8.3", "8.4", "8.5"]'
-      typo3-versions: '["12.4", "13.4", "14.2"]'
+      typo3-versions: '["12.4", "13.4", "14.3"]'
       dependencies: '["highest", "lowest"]'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure to validate against TYPO3 version 14.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->