### PR TITLE
chore(deps): bump typo3 v14 constraint to ^14.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
 		"psr/log": "^3.0.2",
 		"symfony/mailer": "^6.4 || ^7.0 || ^8.0",
 		"symfony/mime": "^6.4 || ^7.0 || ^8.0",
-		"typo3/cms-backend": "^12.0 || ^13.0 || ^14.0",
-		"typo3/cms-beuser": "^12.0 || ^13.0 || ^14.0",
-		"typo3/cms-core": "^12.0 || ^13.0 || ^14.0",
+		"typo3/cms-backend": "^12.0 || ^13.0 || ^14.3",
+		"typo3/cms-beuser": "^12.0 || ^13.0 || ^14.3",
+		"typo3/cms-core": "^12.0 || ^13.0 || ^14.3",
 		"typo3fluid/fluid": "^2.15 || ^4.2 || ^5.0"
 	},
 	"require-dev": {
@@ -33,8 +33,8 @@
 		"mobiledetect/mobiledetectlib": "^4.10.0",
 		"phpunit/phpcov": "^9.0 || ^10.0 || ^11.0 || ^13.0",
 		"phpunit/phpunit": "^10.2 || ^11.0 || ^12.0 || ^13.0",
-		"typo3/cms-base-distribution": "^12.4 || ^13.4 || ^14.0",
-		"typo3/cms-lowlevel": "^12.4 || ^13.4 || ^14.0"
+		"typo3/cms-base-distribution": "^12.4 || ^13.4 || ^14.3",
+		"typo3/cms-lowlevel": "^12.4 || ^13.4 || ^14.3"
 	},
 	"suggest": {
 		"mobiledetect/mobiledetectlib": "Provides more accurate and comprehensive browser/OS/device detection. Falls back to basic detection if not installed."

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce4ee8a5a07fa4b6e98ad1f28d1f6152",
+    "content-hash": "59c7ee35fde960313a1a226250af4bde",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
## Summary

- Bump TYPO3 v14 minimum constraint from `^14.0` to `^14.3` for runtime and dev dependencies
- Align package constraints with the CI test matrix, which already targets 14.3

## Changes

- `composer.json` — raise `typo3/cms-backend`, `typo3/cms-beuser`, `typo3/cms-core`, `typo3/cms-base-distribution`, and `typo3/cms-lowlevel` v14 constraints to `^14.3`
- `composer.lock` — updated content hash