### PR TITLE
docs: static TYPO3 support version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # TYPO3 extension `typo3_login_warning`
 
 [![Latest Stable Version](https://typo3-badges.dev/badge/typo3_login_warning/version/shields.svg)](https://extensions.typo3.org/extension/typo3_login_warning)
-[![Supported TYPO3 versions](https://typo3-badges.dev/badge/typo3_login_warning/typo3/shields.svg)](https://extensions.typo3.org/extension/typo3_login_warning)
+![TYPO3](https://img.shields.io/badge/TYPO3-12.0%20%7C%2013.0%20%7C%2014.3-orange.svg)
 [![Coverage](https://img.shields.io/coverallsCoverage/github/move-elevator/typo3-login-warning?logo=coveralls)](https://coveralls.io/github/move-elevator/typo3-login-warning)
 [![CGL](https://img.shields.io/github/actions/workflow/status/move-elevator/typo3-login-warning/cgl.yml?label=cgl&logo=github)](https://github.com/move-elevator/typo3-login-warning/actions/workflows/cgl.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/move-elevator/typo3-login-warning/tests.yml?label=tests&logo=github)](https://github.com/move-elevator/typo3-login-warning/actions/workflows/tests.yml)


### PR DESCRIPTION
Replaces the dynamic `typo3-badges.dev` "Supported TYPO3 versions" badge with a single static shields.io badge listing the supported TYPO3 versions derived from the `typo3/cms-core` constraint in `composer.json`.

- No external badge service dependency for version support