### PR TITLE
fix: prevent detector and notifier exceptions from breaking backend login

### DIFF
--- a/Classes/Security/LoginNotification.php
+++ b/Classes/Security/LoginNotification.php
@@ -20,6 +20,7 @@ use MoveElevator\Typo3LoginWarning\Registry\{DetectorRegistry, NotificationRegis
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\{LoggerAwareInterface, LoggerAwareTrait};
+use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Authentication\Event\AfterUserLoggedInEvent;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
@@ -76,7 +77,7 @@ final class LoginNotification implements LoggerAwareInterface
                 continue;
             }
 
-            if ($detector->detect($currentUserArray, $currentDetectorConfiguration, $event->getRequest())) {
+            if ($this->detectSafely($detector, $currentUserArray, $currentDetectorConfiguration, $event->getRequest())) {
                 $currentDetector = $detector;
                 break;
             }
@@ -86,13 +87,49 @@ final class LoginNotification implements LoggerAwareInterface
             return;
         }
 
-        $this->sendNotification(
-            $currentUser,
-            $event->getRequest() ?? $GLOBALS['TYPO3_REQUEST'] ?? ServerRequestFactory::fromGlobals()->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE),
-            $currentDetector,
-            $globalNotificationConfig,
-            $currentDetectorConfiguration,
-        );
+        try {
+            $this->sendNotification(
+                $currentUser,
+                $this->resolveRequest($event->getRequest()),
+                $currentDetector,
+                $globalNotificationConfig,
+                $currentDetectorConfiguration,
+            );
+        } catch (Throwable $exception) {
+            // Event listeners or notification setup must never break the backend login itself.
+            $this->logger?->error('Login warning notification failed', [
+                'detector' => $currentDetector::class,
+                'userId' => $currentUserArray['uid'] ?? 0,
+                'exception' => $exception,
+            ]);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $userArray
+     * @param array<string, mixed> $configuration
+     */
+    private function detectSafely(DetectorInterface $detector, array $userArray, array $configuration, ?ServerRequestInterface $request): bool
+    {
+        try {
+            return $detector->detect($userArray, $configuration, $request);
+        } catch (Throwable $exception) {
+            // A failing detector must never break the backend login itself.
+            $this->logger?->error('Login warning detector "{detector}" failed', [
+                'detector' => $detector::class,
+                'userId' => $userArray['uid'] ?? 0,
+                'exception' => $exception,
+            ]);
+
+            return false;
+        }
+    }
+
+    private function resolveRequest(?ServerRequestInterface $request): ServerRequestInterface
+    {
+        return $request
+            ?? $GLOBALS['TYPO3_REQUEST']
+            ?? ServerRequestFactory::fromGlobals()->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
     }
 
     /**
@@ -134,13 +171,22 @@ final class LoginNotification implements LoggerAwareInterface
         }
 
         foreach ($this->notificationRegistry->getNotifiers() as $notifier) {
-            $notifier->notify(
-                $user,
-                $request,
-                $detector::class,
-                $event->getNotificationConfig(),
-                $event->getAdditionalData(),
-            );
+            try {
+                $notifier->notify(
+                    $user,
+                    $request,
+                    $detector::class,
+                    $event->getNotificationConfig(),
+                    $event->getAdditionalData(),
+                );
+            } catch (Throwable $exception) {
+                // A failing notifier must neither break the login nor prevent other notifiers.
+                $this->logger?->error('Login warning notifier "{notifier}" failed', [
+                    'notifier' => $notifier::class,
+                    'userId' => $user->user['uid'] ?? 0,
+                    'exception' => $exception,
+                ]);
+            }
         }
     }
 }

--- a/Tests/Unit/Security/LoginNotificationTest.php
+++ b/Tests/Unit/Security/LoginNotificationTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Authentication\Event\AfterUserLoggedInEvent;
 
@@ -170,6 +171,129 @@ final class LoginNotificationTest extends TestCase
             ->method('build')
             ->with($mockDetector::class)
             ->willReturn(['notificationReceiver' => 'recipients']);
+
+        ($this->subject)($event);
+    }
+
+    public function testDetectorExceptionDoesNotBreakLoginAndNextDetectorRuns(): void
+    {
+        $user = $this->createMock(BackendUserAuthentication::class);
+        $user->user = ['uid' => 123, 'username' => 'testuser'];
+        $request = $this->createMock(ServerRequestInterface::class);
+        $event = new AfterUserLoggedInEvent($user, $request);
+
+        $throwingDetector = $this->createMock(\MoveElevator\Typo3LoginWarning\Detector\DetectorInterface::class);
+        $throwingDetector->method('shouldDetectForUser')->willReturn(true);
+        $throwingDetector->expects(self::once())
+            ->method('detect')
+            ->willThrowException(new RuntimeException('Detector failure'));
+
+        $matchingDetector = $this->createMock(\MoveElevator\Typo3LoginWarning\Detector\DetectorInterface::class);
+        $matchingDetector->method('shouldDetectForUser')->willReturn(true);
+        $matchingDetector->expects(self::once())->method('detect')->willReturn(true);
+        $matchingDetector->method('getAdditionalData')->willReturn([]);
+
+        $mockNotifier = $this->createMock(\MoveElevator\Typo3LoginWarning\Notification\NotifierInterface::class);
+        $mockNotifier->expects(self::once())->method('notify');
+
+        $this->subject = new LoginNotification(
+            new DetectorRegistry([$throwingDetector, $matchingDetector]),
+            $this->configBuilder,
+            new NotificationRegistry([$mockNotifier]),
+            $this->eventDispatcher,
+        );
+        $this->subject->setLogger($this->logger);
+
+        $this->configBuilder->method('buildNotificationConfig')->willReturn([]);
+        $this->configBuilder->method('isActive')->willReturn(true);
+        $this->configBuilder->method('build')->willReturn([]);
+
+        $this->logger->expects(self::once())
+            ->method('error')
+            ->with('Login warning detector "{detector}" failed', self::callback(
+                static fn (array $context): bool => $context['exception'] instanceof RuntimeException,
+            ));
+
+        ($this->subject)($event);
+    }
+
+    public function testNotifierExceptionDoesNotBreakLoginAndOtherNotifiersRun(): void
+    {
+        $user = $this->createMock(BackendUserAuthentication::class);
+        $user->user = ['uid' => 123, 'username' => 'testuser'];
+        $request = $this->createMock(ServerRequestInterface::class);
+        $event = new AfterUserLoggedInEvent($user, $request);
+
+        $mockDetector = $this->createMock(\MoveElevator\Typo3LoginWarning\Detector\DetectorInterface::class);
+        $mockDetector->method('shouldDetectForUser')->willReturn(true);
+        $mockDetector->method('detect')->willReturn(true);
+        $mockDetector->method('getAdditionalData')->willReturn([]);
+
+        $throwingNotifier = $this->createMock(\MoveElevator\Typo3LoginWarning\Notification\NotifierInterface::class);
+        $throwingNotifier->expects(self::once())
+            ->method('notify')
+            ->willThrowException(new RuntimeException('Notifier failure'));
+
+        $workingNotifier = $this->createMock(\MoveElevator\Typo3LoginWarning\Notification\NotifierInterface::class);
+        $workingNotifier->expects(self::once())->method('notify');
+
+        $this->subject = new LoginNotification(
+            new DetectorRegistry([$mockDetector]),
+            $this->configBuilder,
+            new NotificationRegistry([$throwingNotifier, $workingNotifier]),
+            $this->eventDispatcher,
+        );
+        $this->subject->setLogger($this->logger);
+
+        $this->configBuilder->method('buildNotificationConfig')->willReturn([]);
+        $this->configBuilder->method('isActive')->willReturn(true);
+        $this->configBuilder->method('build')->willReturn([]);
+
+        $this->logger->expects(self::once())
+            ->method('error')
+            ->with('Login warning notifier "{notifier}" failed', self::callback(
+                static fn (array $context): bool => $context['exception'] instanceof RuntimeException,
+            ));
+
+        ($this->subject)($event);
+    }
+
+    public function testEventListenerExceptionDoesNotBreakLogin(): void
+    {
+        $user = $this->createMock(BackendUserAuthentication::class);
+        $user->user = ['uid' => 123, 'username' => 'testuser'];
+        $request = $this->createMock(ServerRequestInterface::class);
+        $event = new AfterUserLoggedInEvent($user, $request);
+
+        $mockDetector = $this->createMock(\MoveElevator\Typo3LoginWarning\Detector\DetectorInterface::class);
+        $mockDetector->method('shouldDetectForUser')->willReturn(true);
+        $mockDetector->method('detect')->willReturn(true);
+        $mockDetector->method('getAdditionalData')->willReturn([]);
+
+        $mockNotifier = $this->createMock(\MoveElevator\Typo3LoginWarning\Notification\NotifierInterface::class);
+        $mockNotifier->expects(self::never())->method('notify');
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->method('dispatch')
+            ->willThrowException(new RuntimeException('Listener failure'));
+
+        $this->subject = new LoginNotification(
+            new DetectorRegistry([$mockDetector]),
+            $this->configBuilder,
+            new NotificationRegistry([$mockNotifier]),
+            $eventDispatcher,
+        );
+        $this->subject->setLogger($this->logger);
+
+        $this->configBuilder->method('buildNotificationConfig')->willReturn([]);
+        $this->configBuilder->method('isActive')->willReturn(true);
+        $this->configBuilder->method('build')->willReturn([]);
+
+        $this->logger->expects(self::once())
+            ->method('error')
+            ->with('Login warning notification failed', self::callback(
+                static fn (array $context): bool => $context['exception'] instanceof RuntimeException,
+            ));
 
         ($this->subject)($event);
     }


### PR DESCRIPTION
## Summary

- The `LoginNotification` event listener runs synchronously inside `AfterUserLoggedInEvent` — any uncaught exception from a detector, an event listener, or a notifier previously propagated into the login request and broke the backend login with a 500 response.
- Real-world triggers: an invalid timezone in the OutOfOffice configuration (`new DateTimeZone()` throws), a missing HMAC/encryption key in `NewIpDetector`, or a unique-constraint race in `IpLogRepository::addHash()` on concurrent logins.
- Detector failures are now caught per detector (logged, remaining detectors still run), notifier failures are caught per notifier (logged, remaining notifiers still run), and the notification dispatch itself has a last-resort guard for throwing `ModifyLoginNotificationEvent` listeners.

## Changes

- `Classes/Security/LoginNotification.php` - Wrap `detect()` per detector (`detectSafely()`), wrap each `notify()` call, guard `sendNotification()` against throwing event listeners; extract `resolveRequest()`
- `Tests/Unit/Security/LoginNotificationTest.php` - New tests: throwing detector lets next detector run, throwing notifier lets other notifiers run, throwing event listener does not break the login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Login notifications are now more resilient when detectors, notification handlers, or event listeners fail.
  * If one step throws an error, the login flow continues and other notification handlers can still run.
  * Failures are logged for troubleshooting instead of interrupting backend login handling.
* **Tests**
  * Added coverage for error handling to confirm login notifications keep working when individual components fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->