### PR TITLE
feat: disable IP geolocation lookup by default

### DIFF
--- a/Classes/Configuration/DetectorConfigurationBuilder.php
+++ b/Classes/Configuration/DetectorConfigurationBuilder.php
@@ -137,7 +137,7 @@ class DetectorConfigurationBuilder implements LoggerAwareInterface
     {
         return [
             'hashIpAddress' => (bool) ($config['hashIpAddress'] ?? true),
-            'fetchGeolocation' => (bool) ($config['fetchGeolocation'] ?? true),
+            'fetchGeolocation' => (bool) ($config['fetchGeolocation'] ?? false),
             'affectedUsers' => $config['affectedUsers'] ?? 'all',
             'notificationReceiver' => $config['notificationReceiver'] ?? 'recipients',
             'whitelist' => $this->parseCommaSeparatedList($config['whitelist'] ?? '127.0.0.1'),

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ An IP geolocation lookup and a device information check can be enabled to add mo
 |---------|-------------|-------------|
 | **Active** | Enable New IP detector | `true`      |
 | **Hash IP Addresses** | Hash IP addresses for privacy (HMAC‑SHA‑256) | `true`      |
-| **Fetch Geolocation** | Enable IP geolocation lookup | `true`      |
+| **Fetch Geolocation** | Enable IP geolocation lookup (opt-in, see [Geolocation](#geolocation)) | `false`     |
 | **Include Device Information** | Include browser and OS information in notification emails | `true`      |
 | **IP Whitelist** | Comma-separated list of whitelisted IPs/networks (supports CIDR notation like `192.168.1.0/24`) | `127.0.0.1` |
 | **Affected Users** | Which users should trigger this detector: `All Users`, `Only Admins`, `Only System Maintainers` | `All Users` |
@@ -107,6 +107,9 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['typo3_login_warning']['hmacKey'] = 'your
 #### Geolocation
 
 If `Fetch Geolocation` is enabled, the extension will use the [ip-api.com](https://ip-api.com/) service to fetch geolocation information for the IP address. Only public IP addresses will be looked up to respect privacy.
+
+> [!WARNING]
+> Geolocation lookup is **disabled by default** and is an explicit opt-in: it transfers the login IP address (personal data under GDPR) to the external ip-api.com service, using unencrypted HTTP on the free tier. Before enabling it, check your data protection requirements (third-country transfer, privacy policy, data processing agreement) and note that the free ip-api.com endpoint is limited to non-commercial use. Consider providing your own `GeolocationServiceInterface` implementation (see below) if you need an EU-hosted or TLS-secured provider.
 
 > [!TIP]
 > You can implement your own geolocation service by implementing the `GeolocationServiceInterface` and registering it in the DI container.

--- a/Tests/Unit/Configuration/DetectorConfigurationBuilderTest.php
+++ b/Tests/Unit/Configuration/DetectorConfigurationBuilderTest.php
@@ -116,7 +116,7 @@ final class DetectorConfigurationBuilderTest extends TestCase
 
         self::assertSame([
             'hashIpAddress' => true,
-            'fetchGeolocation' => true,
+            'fetchGeolocation' => false,
             'affectedUsers' => 'all',
             'notificationReceiver' => 'recipients',
             'whitelist' => ['127.0.0.1'],
@@ -132,7 +132,7 @@ final class DetectorConfigurationBuilderTest extends TestCase
                 'newIp' => [
                     'active' => true,
                     'hashIpAddress' => false,
-                    'fetchGeolocation' => false,
+                    'fetchGeolocation' => true,
                     'affectedUsers' => 'admins',
                     'notificationReceiver' => 'both',
                     'whitelist' => '192.168.1.1, 10.0.0.1',
@@ -143,7 +143,7 @@ final class DetectorConfigurationBuilderTest extends TestCase
 
         self::assertSame([
             'hashIpAddress' => false,
-            'fetchGeolocation' => false,
+            'fetchGeolocation' => true,
             'affectedUsers' => 'admins',
             'notificationReceiver' => 'both',
             'whitelist' => ['192.168.1.1', '10.0.0.1'],
@@ -327,7 +327,7 @@ final class DetectorConfigurationBuilderTest extends TestCase
         // Should get defaults from buildNewIpConfig
         self::assertSame([
             'hashIpAddress' => true,
-            'fetchGeolocation' => true,
+            'fetchGeolocation' => false,
             'affectedUsers' => 'all',
             'notificationReceiver' => 'recipients',
             'whitelist' => ['127.0.0.1'],
@@ -346,7 +346,7 @@ final class DetectorConfigurationBuilderTest extends TestCase
 
         self::assertSame([
             'hashIpAddress' => true,
-            'fetchGeolocation' => true,
+            'fetchGeolocation' => false,
             'affectedUsers' => 'all',
             'notificationReceiver' => 'recipients',
             'whitelist' => ['127.0.0.1'],

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -19,8 +19,8 @@ notificationRecipients =
 # cat=newip/newip/020; type=boolean; label=Hash IP Addresses:Hash the persistence of IP addresses for privacy reasons (SHA-256)
 newIp.hashIpAddress = 1
 
-# cat=newip/newip/030; type=boolean; label=Fetch Geolocation:Enable IP geolocation lookup for new IPs
-newIp.fetchGeolocation = 1
+# cat=newip/newip/030; type=boolean; label=Fetch Geolocation:Enable IP geolocation lookup for new IPs. Transfers the login IP address to the external ip-api.com service - check your privacy requirements before enabling.
+newIp.fetchGeolocation = 0
 
 # cat=newip/newip/040; type=boolean; label=Include Device Information:Include browser and OS information in notification emails
 newIp.includeDeviceInfo = 1


### PR DESCRIPTION
## Summary

- IP geolocation lookup via ip-api.com is now an explicit opt-in (`newIp.fetchGeolocation` defaults to `0`). Previously it was enabled by default, transferring the login IP address of every backend user — personal data under GDPR — to an external third-country service over unencrypted HTTP without any active decision by the administrator.
- The README documents the privacy implications (third-country transfer, HTTP-only free tier, non-commercial usage restriction of ip-api.com) and points to the `GeolocationServiceInterface` for EU-hosted or TLS-secured alternatives.

## Changes

- `ext_conf_template.txt` - Default `newIp.fetchGeolocation = 0`, label mentions the external data transfer
- `Classes/Configuration/DetectorConfigurationBuilder.php` - Fallback default for `fetchGeolocation` changed to `false`
- `README.md` - Privacy warning in the Geolocation section, default value updated in the options table
- `Tests/Unit/Configuration/DetectorConfigurationBuilderTest.php` - Default expectations updated; custom-values test now verifies the opt-in override

## Note for existing installations

Installations that never saved the extension configuration inherit the new default and lose geolocation data in notification mails until they actively enable it — this is the intended opt-in behavior.