### PR TITLE
fix: expose only whitelisted user fields to email templates

### DIFF
--- a/Classes/Notification/EmailNotification.php
+++ b/Classes/Notification/EmailNotification.php
@@ -35,6 +35,13 @@ class EmailNotification implements NotifierInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
+    /**
+     * User record fields exposed to the (overridable) email templates. The full
+     * be_users row must never reach the template context as it contains sensitive
+     * data like the password hash and the MFA configuration.
+     */
+    private const TEMPLATE_USER_FIELDS = ['uid', 'username', 'realName', 'email', 'admin', 'lang'];
+
     public function __construct(
         private readonly MailerInterface $mailer,
     ) {}
@@ -112,12 +119,13 @@ class EmailNotification implements NotifierInterface, LoggerAwareInterface
     private function sendNotificationEmails(BackendUserAuthentication $user, ServerRequestInterface $request, string $triggerClass, array $recipientsList, array $additionalValues): void
     {
         $userEmail = trim($user->user['email'] ?? '');
+        $templateUser = array_intersect_key($user->user ?? [], array_flip(self::TEMPLATE_USER_FIELDS));
 
         foreach ($recipientsList as $recipient) {
             $isUserNotification = '' !== $userEmail && $recipient === $userEmail;
 
             $values = [
-                'user' => $user->user,
+                'user' => $templateUser,
                 'prefix' => $user->isAdmin() ? '[AdminLoginWarning]' : '[LoginWarning]',
                 'language' => $user->user['lang'] ?? 'default',
                 'headline' => 'TYPO3 Backend Login notification',

--- a/Tests/Unit/Notification/EmailNotificationTest.php
+++ b/Tests/Unit/Notification/EmailNotificationTest.php
@@ -362,6 +362,44 @@ final class EmailNotificationTest extends TestCase
         $this->subject->notify($user, $this->request, 'TestTrigger', $configuration);
     }
 
+    public function testNotifyExposesOnlyWhitelistedUserFieldsToTemplate(): void
+    {
+        $user = $this->createMockBackendUser([
+            'uid' => 123,
+            'username' => 'testuser',
+            'realName' => 'Test User',
+            'email' => 'user@example.com',
+            'admin' => 1,
+            'lang' => 'en',
+            'password' => '$argon2i$v=19$m=65536,t=16,p=1$secret-hash',
+            'mfa' => '{"totp":{"secret":"secret-totp-seed"}}',
+            'uc' => 'a:1:{s:3:"foo";s:3:"bar";}',
+            'TSconfig' => 'options.foo = 1',
+        ]);
+        $configuration = ['recipient' => 'admin@example.com'];
+
+        $fluidEmail = $this->createMock(FluidEmail::class);
+        $fluidEmail->method('to')->willReturnSelf();
+        $fluidEmail->method('setRequest')->willReturnSelf();
+        $fluidEmail->method('setTemplate')->willReturnSelf();
+        $fluidEmail->expects(self::once())->method('assignMultiple')->with(
+            self::callback(static fn (array $vars): bool => [
+                'uid' => 123,
+                'username' => 'testuser',
+                'realName' => 'Test User',
+                'email' => 'user@example.com',
+                'admin' => 1,
+                'lang' => 'en',
+            ] === $vars['user']),
+        )->willReturnSelf();
+
+        GeneralUtility::addInstance(FluidEmail::class, $fluidEmail);
+
+        $this->mailer->expects(self::once())->method('send');
+
+        $this->subject->notify($user, $this->request, 'TestTrigger', $configuration);
+    }
+
     /**
      * @param array<string, mixed> $userData
      */


### PR DESCRIPTION
## Summary

- The notification email previously assigned the complete `be_users` row as the `user` template variable — including the password hash, the MFA configuration, `uc` and TSconfig. Since email templates are an official override point (`MAIL.templateRootPaths`), a customized template (or a stray `<f:debug>{user}</f:debug>`) could leak credential material into an email.
- Following the data minimization principle, only the fields the templates actually need are now exposed: `uid`, `username`, `realName`, `email`, `admin`, `lang`.

## Changes

- `Classes/Notification/EmailNotification.php` - Filter the user record through a field whitelist (`TEMPLATE_USER_FIELDS`) before assigning it to the Fluid context
- `Tests/Unit/Notification/EmailNotificationTest.php` - New test asserting sensitive fields (password hash, MFA secrets, uc, TSconfig) never reach the template variables

## Compatibility

Custom templates using `{user.username}`, `{user.realName}`, `{user.email}` etc. keep working. Templates relying on other be_users columns would need those fields added to the whitelist — intentionally a conscious decision from now on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened the user information included in login notification emails so only a limited set of fields is exposed in templates.
  * Prevented sensitive account details from appearing in email content.
* **Tests**
  * Added coverage to verify that only approved user fields are passed to the email template and that the notification is sent as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->