### PR TITLE
fix: race-safe IP log registration with fewer queries

### DIFF
--- a/Classes/Detector/NewIpDetector.php
+++ b/Classes/Detector/NewIpDetector.php
@@ -63,9 +63,8 @@ class NewIpDetector extends AbstractDetector
 
         $identifierHash = $this->generateIdentifierHash($userId, $ipForStorage);
 
-        if (!$this->ipLogRepository->findByHash($identifierHash)) {
+        if ($this->ipLogRepository->registerIdentifier($identifierHash)) {
             $this->collectAdditionalData($configuration, $rawIpAddress, $request);
-            $this->ipLogRepository->addHash($identifierHash);
 
             return true;
         }

--- a/Classes/Domain/Repository/IpLogRepository.php
+++ b/Classes/Domain/Repository/IpLogRepository.php
@@ -14,7 +14,8 @@ declare(strict_types=1);
 namespace MoveElevator\Typo3LoginWarning\Domain\Repository;
 
 use Doctrine\DBAL\Exception;
-use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 
 /**
  * IpLogRepository.
@@ -29,49 +30,37 @@ class IpLogRepository
     public function __construct(private readonly ConnectionPool $connectionPool) {}
 
     /**
+     * Registers a sighting of the given identifier and returns whether it was seen
+     * for the first time. Updates the timestamp first and only inserts when no row
+     * was touched, so concurrent logins racing on the same identifier cannot fail
+     * on the unique identifier_hash constraint.
+     *
      * @throws Exception
      */
-    public function findByHash(string $identifierHash): bool
+    public function registerIdentifier(string $identifierHash): bool
     {
-        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_NAME);
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE_NAME);
 
-        $result = $queryBuilder
-            ->select('*')
-            ->from(self::TABLE_NAME)
-            ->where(
-                $queryBuilder->expr()->eq('identifier_hash', $queryBuilder->createNamedParameter($identifierHash, Connection::PARAM_STR)),
-            )
-            ->executeQuery()->fetchAssociative();
+        $affectedRows = $connection->update(
+            self::TABLE_NAME,
+            ['tstamp' => time()],
+            ['identifier_hash' => $identifierHash],
+        );
 
-        if (false !== $result) {
-            $this->updateTimestamp($identifierHash);
-
-            return true;
+        if ($affectedRows > 0) {
+            return false;
         }
 
-        return false;
-    }
-
-    public function addHash(string $identifierHash): void
-    {
-        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_NAME);
-        $queryBuilder
-            ->insert(self::TABLE_NAME)
-            ->values([
+        try {
+            $connection->insert(self::TABLE_NAME, [
                 'identifier_hash' => $identifierHash,
-            ])
-            ->executeStatement();
-    }
+                'tstamp' => time(),
+            ]);
+        } catch (UniqueConstraintViolationException) {
+            // A concurrent login registered the identifier in the meantime.
+            return false;
+        }
 
-    private function updateTimestamp(string $identifierHash): void
-    {
-        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_NAME);
-        $queryBuilder
-            ->update(self::TABLE_NAME)
-            ->set('tstamp', time())
-            ->where(
-                $queryBuilder->expr()->eq('identifier_hash', $queryBuilder->createNamedParameter($identifierHash, Connection::PARAM_STR)),
-            )
-            ->executeStatement();
+        return true;
     }
 }

--- a/Tests/Unit/Detector/NewIpDetectorTest.php
+++ b/Tests/Unit/Detector/NewIpDetectorTest.php
@@ -63,7 +63,7 @@ final class NewIpDetectorTest extends TestCase
         // Should not be called as exception is thrown earlier
         $ipLogRepository
             ->expects(self::never())
-            ->method('findByHash');
+            ->method('registerIdentifier');
 
         $subject = new NewIpDetector($ipLogRepository);
 
@@ -83,8 +83,7 @@ final class NewIpDetectorTest extends TestCase
         $request = $this->createMockRequest(ip: '192.168.1.1');
 
         $ipLogRepository = $this->createMock(IpLogRepository::class);
-        $ipLogRepository->expects(self::never())->method('findByHash');
-        $ipLogRepository->expects(self::never())->method('addHash');
+        $ipLogRepository->expects(self::never())->method('registerIdentifier');
 
         $subject = new NewIpDetector($ipLogRepository);
         $result = $subject->detect($user, $configuration, $request);
@@ -102,14 +101,9 @@ final class NewIpDetectorTest extends TestCase
         $ipLogRepository = $this->createMock(IpLogRepository::class);
         $ipLogRepository
             ->expects(self::once())
-            ->method('findByHash')
+            ->method('registerIdentifier')
             ->with(self::matchesRegularExpression('/^[a-f0-9]{64}$/'))
-            ->willReturn(false);
-
-        $ipLogRepository
-            ->expects(self::once())
-            ->method('addHash')
-            ->with(self::matchesRegularExpression('/^[a-f0-9]{64}$/'));
+            ->willReturn(true);
 
         $subject = new NewIpDetector($ipLogRepository);
         $result = $subject->detect($user, $configuration, $request);
@@ -127,13 +121,9 @@ final class NewIpDetectorTest extends TestCase
         $ipLogRepository = $this->createMock(IpLogRepository::class);
         $ipLogRepository
             ->expects(self::once())
-            ->method('findByHash')
+            ->method('registerIdentifier')
             ->with(self::matchesRegularExpression('/^[a-f0-9]{64}$/'))
-            ->willReturn(true);
-
-        $ipLogRepository
-            ->expects(self::never())
-            ->method('addHash');
+            ->willReturn(false);
 
         $subject = new NewIpDetector($ipLogRepository);
         $result = $subject->detect($user, $configuration, $request);
@@ -151,14 +141,9 @@ final class NewIpDetectorTest extends TestCase
         $ipLogRepository = $this->createMock(IpLogRepository::class);
         $ipLogRepository
             ->expects(self::once())
-            ->method('findByHash')
+            ->method('registerIdentifier')
             ->with(self::matchesRegularExpression('/^[a-f0-9]{64}$/'))
-            ->willReturn(false);
-
-        $ipLogRepository
-            ->expects(self::once())
-            ->method('addHash')
-            ->with(self::matchesRegularExpression('/^[a-f0-9]{64}$/'));
+            ->willReturn(true);
 
         $subject = new NewIpDetector($ipLogRepository);
         $result = $subject->detect($user, $configuration, $request);
@@ -176,14 +161,9 @@ final class NewIpDetectorTest extends TestCase
         $ipLogRepository = $this->createMock(IpLogRepository::class);
         $ipLogRepository
             ->expects(self::once())
-            ->method('findByHash')
+            ->method('registerIdentifier')
             ->with(self::matchesRegularExpression('/^[a-f0-9]{64}$/'))
-            ->willReturn(false);
-
-        $ipLogRepository
-            ->expects(self::once())
-            ->method('addHash')
-            ->with(self::matchesRegularExpression('/^[a-f0-9]{64}$/'));
+            ->willReturn(true);
 
         $subject = new NewIpDetector($ipLogRepository);
         $result = $subject->detect($user, $configuration, $request);
@@ -206,16 +186,12 @@ final class NewIpDetectorTest extends TestCase
 
         $ipLogRepository
             ->expects(self::once())
-            ->method('findByHash')
-            ->willReturn(false);
+            ->method('registerIdentifier')
+            ->willReturn(true);
 
         $geolocationService
             ->expects(self::never())
             ->method('getLocationData');
-
-        $ipLogRepository
-            ->expects(self::once())
-            ->method('addHash');
 
         $subject = new NewIpDetector($ipLogRepository, $geolocationService);
         $result = $subject->detect($user, $configuration, $request);
@@ -246,16 +222,12 @@ final class NewIpDetectorTest extends TestCase
 
         $ipLogRepository
             ->expects(self::once())
-            ->method('findByHash')
-            ->willReturn(false);
+            ->method('registerIdentifier')
+            ->willReturn(true);
 
         $geolocationService
             ->expects(self::never())
             ->method('getLocationData');
-
-        $ipLogRepository
-            ->expects(self::once())
-            ->method('addHash');
 
         $subject = new NewIpDetector($ipLogRepository, $geolocationService);
         $result = $subject->detect($user, $configuration, $request);
@@ -332,10 +304,8 @@ final class NewIpDetectorTest extends TestCase
 
         $ipLogRepository = $this->createMock(IpLogRepository::class);
         $ipLogRepository->expects(self::once())
-            ->method('findByHash')
-            ->willReturn(false);
-        $ipLogRepository->expects(self::once())
-            ->method('addHash');
+            ->method('registerIdentifier')
+            ->willReturn(true);
 
         $subject = new NewIpDetector($ipLogRepository);
         $result = $subject->detect($user, $configuration, $request);
@@ -361,10 +331,8 @@ final class NewIpDetectorTest extends TestCase
 
         $ipLogRepository = $this->createMock(IpLogRepository::class);
         $ipLogRepository->expects(self::once())
-            ->method('findByHash')
-            ->willReturn(false);
-        $ipLogRepository->expects(self::once())
-            ->method('addHash');
+            ->method('registerIdentifier')
+            ->willReturn(true);
 
         $subject = new NewIpDetector($ipLogRepository);
         $result = $subject->detect($user, $configuration, $request);
@@ -387,10 +355,8 @@ final class NewIpDetectorTest extends TestCase
 
         $ipLogRepository = $this->createMock(IpLogRepository::class);
         $ipLogRepository->expects(self::once())
-            ->method('findByHash')
-            ->willReturn(false);
-        $ipLogRepository->expects(self::once())
-            ->method('addHash');
+            ->method('registerIdentifier')
+            ->willReturn(true);
 
         $subject = new NewIpDetector($ipLogRepository);
         $result = $subject->detect($user, $configuration, $request);
@@ -410,10 +376,8 @@ final class NewIpDetectorTest extends TestCase
 
         $ipLogRepository = $this->createMock(IpLogRepository::class);
         $ipLogRepository->expects(self::once())
-            ->method('findByHash')
-            ->willReturn(false);
-        $ipLogRepository->expects(self::once())
-            ->method('addHash');
+            ->method('registerIdentifier')
+            ->willReturn(true);
 
         $subject = new NewIpDetector($ipLogRepository);
         $result = $subject->detect($user, $configuration, null);
@@ -433,10 +397,8 @@ final class NewIpDetectorTest extends TestCase
 
         $ipLogRepository = $this->createMock(IpLogRepository::class);
         $ipLogRepository->expects(self::once())
-            ->method('findByHash')
-            ->willReturn(false);
-        $ipLogRepository->expects(self::once())
-            ->method('addHash');
+            ->method('registerIdentifier')
+            ->willReturn(true);
 
         $subject = new NewIpDetector($ipLogRepository);
         $result = $subject->detect($user, $configuration, $request);
@@ -456,10 +418,8 @@ final class NewIpDetectorTest extends TestCase
 
         $ipLogRepository = $this->createMock(IpLogRepository::class);
         $ipLogRepository->expects(self::once())
-            ->method('findByHash')
-            ->willReturn(false);
-        $ipLogRepository->expects(self::once())
-            ->method('addHash');
+            ->method('registerIdentifier')
+            ->willReturn(true);
 
         $subject = new NewIpDetector($ipLogRepository);
         $result = $subject->detect($user, $configuration, $request);
@@ -480,10 +440,8 @@ final class NewIpDetectorTest extends TestCase
 
         $ipLogRepository = $this->createMock(IpLogRepository::class);
         $ipLogRepository->expects(self::once())
-            ->method('findByHash')
-            ->willReturn(false);
-        $ipLogRepository->expects(self::once())
-            ->method('addHash');
+            ->method('registerIdentifier')
+            ->willReturn(true);
 
         $subject = new NewIpDetector($ipLogRepository);
         $result = $subject->detect($user, $configuration, $request);

--- a/Tests/Unit/Domain/Repository/IpLogRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/IpLogRepositoryTest.php
@@ -13,13 +13,11 @@ declare(strict_types=1);
 
 namespace MoveElevator\Typo3LoginWarning\Tests\Unit\Domain\Repository;
 
-use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use MoveElevator\Typo3LoginWarning\Domain\Repository\IpLogRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
-use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
-use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 
 use function is_int;
 
@@ -31,164 +29,73 @@ use function is_int;
  */
 final class IpLogRepositoryTest extends TestCase
 {
-    private ConnectionPool&MockObject $connectionPool;
-    private QueryBuilder&MockObject $queryBuilder;
-    private ExpressionBuilder&MockObject $expressionBuilder;
+    private Connection&MockObject $connection;
     private IpLogRepository $subject;
 
     protected function setUp(): void
     {
-        $this->connectionPool = $this->createMock(ConnectionPool::class);
-        $this->queryBuilder = $this->createMock(QueryBuilder::class);
-        $this->expressionBuilder = $this->createMock(ExpressionBuilder::class);
+        $this->connection = $this->createMock(Connection::class);
 
-        $this->connectionPool
-            ->method('getQueryBuilderForTable')
-            ->with('tx_typo3loginwarning_iplog')
-            ->willReturn($this->queryBuilder);
-
-        $this->queryBuilder
-            ->method('expr')
-            ->willReturn($this->expressionBuilder);
-
-        $this->subject = new IpLogRepository($this->connectionPool);
-    }
-
-    public function testFindByHashReturnsTrueAndUpdatesTimestamp(): void
-    {
-        $identifierHash = 'abc123def456';
-
-        // First call for SELECT query
-        $selectQueryBuilder = $this->createMock(QueryBuilder::class);
-        $selectQueryBuilder->expects(self::once())
-            ->method('select')
-            ->with('*')
-            ->willReturnSelf();
-
-        $selectQueryBuilder->expects(self::once())
-            ->method('from')
-            ->with('tx_typo3loginwarning_iplog')
-            ->willReturnSelf();
-
-        $selectQueryBuilder->expects(self::once())
-            ->method('createNamedParameter')
-            ->with($identifierHash, Connection::PARAM_STR)
-            ->willReturn(':hash');
-
-        $selectQueryBuilder->method('expr')
-            ->willReturn($this->expressionBuilder);
-
-        $this->expressionBuilder->method('eq')
-            ->with('identifier_hash', ':hash')
-            ->willReturn('identifier_hash = :hash');
-
-        $selectQueryBuilder->expects(self::once())
-            ->method('where')
-            ->with('identifier_hash = :hash')
-            ->willReturnSelf();
-
-        $result = $this->createMock(Result::class);
-        $result->expects(self::once())
-            ->method('fetchAssociative')
-            ->willReturn(['identifier_hash' => $identifierHash]);
-
-        $selectQueryBuilder->expects(self::once())
-            ->method('executeQuery')
-            ->willReturn($result);
-
-        // Second call for UPDATE query
-        $updateQueryBuilder = $this->createMock(QueryBuilder::class);
-        $updateQueryBuilder->expects(self::once())
-            ->method('update')
-            ->with('tx_typo3loginwarning_iplog')
-            ->willReturnSelf();
-
-        $updateQueryBuilder->expects(self::once())
-            ->method('set')
-            ->with('tstamp', self::callback(static fn ($value): bool => is_int($value) && $value > 0))
-            ->willReturnSelf();
-
-        $updateQueryBuilder->expects(self::once())
-            ->method('createNamedParameter')
-            ->with($identifierHash, Connection::PARAM_STR)
-            ->willReturn(':hash');
-
-        $updateQueryBuilder->method('expr')
-            ->willReturn($this->expressionBuilder);
-
-        $updateQueryBuilder->expects(self::once())
-            ->method('where')
-            ->with('identifier_hash = :hash')
-            ->willReturnSelf();
-
-        $updateQueryBuilder->expects(self::once())
-            ->method('executeStatement')
-            ->willReturn(1);
-
-        // Mock ConnectionPool to return different query builders
         $connectionPool = $this->createMock(ConnectionPool::class);
         $connectionPool
-            ->expects(self::exactly(2))
-            ->method('getQueryBuilderForTable')
+            ->method('getConnectionForTable')
             ->with('tx_typo3loginwarning_iplog')
-            ->willReturnCallback(static function () use ($selectQueryBuilder, $updateQueryBuilder): QueryBuilder {
-                static $callCount = 0;
-                ++$callCount;
+            ->willReturn($this->connection);
 
-                return 1 === $callCount ? $selectQueryBuilder : $updateQueryBuilder;
-            });
-
-        $subject = new IpLogRepository($connectionPool);
-
-        $found = $subject->findByHash($identifierHash);
-
-        self::assertTrue($found);
+        $this->subject = new IpLogRepository($connectionPool);
     }
 
-    public function testFindByHashReturnsFalse(): void
+    public function testRegisterIdentifierReturnsFalseAndUpdatesTimestampForKnownIdentifier(): void
     {
         $identifierHash = 'abc123def456';
 
-        $this->queryBuilder->method('select')->willReturnSelf();
-        $this->queryBuilder->method('from')->willReturnSelf();
-        $this->queryBuilder->method('createNamedParameter')->willReturn(':param');
-        $this->expressionBuilder->method('eq')->willReturn('field = :param');
-        $this->queryBuilder->method('where')->willReturnSelf();
-
-        $result = $this->createMock(Result::class);
-        $result->expects(self::once())
-            ->method('fetchAssociative')
-            ->willReturn(false);
-
-        $this->queryBuilder->expects(self::once())
-            ->method('executeQuery')
-            ->willReturn($result);
-
-        $found = $this->subject->findByHash($identifierHash);
-
-        self::assertFalse($found);
-    }
-
-    public function testAddHash(): void
-    {
-        $identifierHash = 'abc123def456';
-
-        $this->queryBuilder->expects(self::once())
-            ->method('insert')
-            ->with('tx_typo3loginwarning_iplog')
-            ->willReturnSelf();
-
-        $this->queryBuilder->expects(self::once())
-            ->method('values')
-            ->with([
-                'identifier_hash' => $identifierHash,
-            ])
-            ->willReturnSelf();
-
-        $this->queryBuilder->expects(self::once())
-            ->method('executeStatement')
+        $this->connection->expects(self::once())
+            ->method('update')
+            ->with(
+                'tx_typo3loginwarning_iplog',
+                self::callback(static fn (array $data): bool => is_int($data['tstamp']) && $data['tstamp'] > 0),
+                ['identifier_hash' => $identifierHash],
+            )
             ->willReturn(1);
 
-        $this->subject->addHash($identifierHash);
+        $this->connection->expects(self::never())->method('insert');
+
+        self::assertFalse($this->subject->registerIdentifier($identifierHash));
+    }
+
+    public function testRegisterIdentifierInsertsAndReturnsTrueForNewIdentifier(): void
+    {
+        $identifierHash = 'abc123def456';
+
+        $this->connection->expects(self::once())
+            ->method('update')
+            ->willReturn(0);
+
+        $this->connection->expects(self::once())
+            ->method('insert')
+            ->with(
+                'tx_typo3loginwarning_iplog',
+                self::callback(static fn (array $data): bool => $data['identifier_hash'] === $identifierHash
+                    && is_int($data['tstamp'])
+                    && $data['tstamp'] > 0),
+            )
+            ->willReturn(1);
+
+        self::assertTrue($this->subject->registerIdentifier($identifierHash));
+    }
+
+    public function testRegisterIdentifierReturnsFalseWhenConcurrentLoginInsertedFirst(): void
+    {
+        $identifierHash = 'abc123def456';
+
+        $this->connection->expects(self::once())
+            ->method('update')
+            ->willReturn(0);
+
+        $this->connection->expects(self::once())
+            ->method('insert')
+            ->willThrowException($this->createMock(UniqueConstraintViolationException::class));
+
+        self::assertFalse($this->subject->registerIdentifier($identifierHash));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
 	"require": {
 		"php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
 		"ext-filter": "*",
+		"doctrine/dbal": "^3.7 || ^4.0",
 		"psr/event-dispatcher": "^1.0",
 		"psr/http-client": "^1.0.3",
 		"psr/http-message": "^1.0 || ^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "964cb9447ce57bb9cb8339db93f672ee",
+    "content-hash": "2c985d367d6cfecef21900bbb17f137e",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -9800,5 +9800,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary

- Two concurrent logins from the same new (user, IP) pair could both pass `findByHash()` and then collide in `addHash()` on the `UNIQUE KEY identifier_hash` — the uncaught `UniqueConstraintViolationException` propagated into the login request.
- `findByHash()`/`addHash()`/`updateTimestamp()` are replaced by a single `registerIdentifier()`: it updates the timestamp first (known identifier → 1 query instead of 2), and only inserts when no row was touched, treating a unique-constraint violation as "already seen".
- New rows now get a proper `tstamp` on insert (previously they kept the column default `0` until the second sighting), which makes the timestamp usable for retention cleanup.

## Changes

- `Classes/Domain/Repository/IpLogRepository.php` - Single `registerIdentifier(): bool` (update-then-insert, catches `UniqueConstraintViolationException`)
- `Classes/Detector/NewIpDetector.php` - Uses `registerIdentifier()` instead of find + add
- `Tests/Unit/Domain/Repository/IpLogRepositoryTest.php` - Rewritten for the new method incl. the concurrent-insert case
- `Tests/Unit/Detector/NewIpDetectorTest.php` - Repository mocks updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved IP detection and tracking so new and previously seen IPs are handled more reliably.
  * Added support for updated database handling to make IP logging more robust.

* **Bug Fixes**
  * Reduced the chance of duplicate IP entries during concurrent requests.
  * Improved detection behavior for existing IPs and first-time IPs.

* **Tests**
  * Updated automated tests to cover the revised IP registration flow and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->