### PR TITLE
feat: add IP log cleanup command with retention period

### DIFF
--- a/Classes/Command/CleanupIpLogCommand.php
+++ b/Classes/Command/CleanupIpLogCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_login_warning" TYPO3 CMS extension.
+ *
+ * (c) 2025-2026 Konrad Michalik <km@move-elevator.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MoveElevator\Typo3LoginWarning\Command;
+
+use MoveElevator\Typo3LoginWarning\Domain\Repository\IpLogRepository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\{InputInterface, InputOption};
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function sprintf;
+
+/**
+ * CleanupIpLogCommand.
+ *
+ * @author Konrad Michalik <km@move-elevator.de>
+ * @license GPL-2.0-or-later
+ */
+final class CleanupIpLogCommand extends Command
+{
+    private const SECONDS_PER_DAY = 86400;
+
+    public function __construct(private readonly IpLogRepository $ipLogRepository)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('typo3loginwarning:iplog:cleanup')
+            ->setDescription('Deletes IP log entries that have not been seen for a given number of days.')
+            ->addOption('days', 'd', InputOption::VALUE_REQUIRED, 'Delete entries whose last sighting is older than this number of days', '365')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Only report how many entries would be deleted');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $days = (int) $input->getOption('days');
+        if ($days < 1) {
+            $io->error('The --days option must be a positive integer.');
+
+            return Command::FAILURE;
+        }
+
+        $threshold = time() - $days * self::SECONDS_PER_DAY;
+
+        if (true === $input->getOption('dry-run')) {
+            $count = $this->ipLogRepository->countEntriesLastSeenBefore($threshold);
+            $io->writeln(sprintf('%d IP log entries would be deleted (not seen for more than %d days).', $count, $days));
+
+            return Command::SUCCESS;
+        }
+
+        $deleted = $this->ipLogRepository->deleteEntriesLastSeenBefore($threshold);
+        $io->writeln(sprintf('Deleted %d IP log entries (not seen for more than %d days).', $deleted, $days));
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Domain/Repository/IpLogRepository.php
+++ b/Classes/Domain/Repository/IpLogRepository.php
@@ -15,8 +15,7 @@ namespace MoveElevator\Typo3LoginWarning\Domain\Repository;
 
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-use TYPO3\CMS\Core\Database\Connection;
-use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
 
 /**
  * IpLogRepository.

--- a/Classes/Domain/Repository/IpLogRepository.php
+++ b/Classes/Domain/Repository/IpLogRepository.php
@@ -63,6 +63,34 @@ class IpLogRepository
             ->executeStatement();
     }
 
+    /**
+     * @throws Exception
+     */
+    public function countEntriesLastSeenBefore(int $timestamp): int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_NAME);
+
+        return (int) $queryBuilder
+            ->count('uid')
+            ->from(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->lt('tstamp', $queryBuilder->createNamedParameter($timestamp, Connection::PARAM_INT)),
+            )
+            ->executeQuery()->fetchOne();
+    }
+
+    public function deleteEntriesLastSeenBefore(int $timestamp): int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_NAME);
+
+        return $queryBuilder
+            ->delete(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->lt('tstamp', $queryBuilder->createNamedParameter($timestamp, Connection::PARAM_INT)),
+            )
+            ->executeStatement();
+    }
+
     private function updateTimestamp(string $identifierHash): void
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_NAME);

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -33,6 +33,13 @@ services:
     tags:
       - { name: typo3_login_warning.notifier }
 
+  MoveElevator\Typo3LoginWarning\Command\CleanupIpLogCommand:
+    tags:
+      - name: console.command
+        command: 'typo3loginwarning:iplog:cleanup'
+        description: 'Delete IP log entries that have not been seen for a given number of days'
+        schedulable: true
+
   MoveElevator\Typo3LoginWarning\Security\LoginNotification:
     tags:
       - name: event.listener

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ An IP geolocation lookup and a device information check can be enabled to add mo
 $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['typo3_login_warning']['hmacKey'] = 'your-secure-random-key';
 ```
 
+#### IP log cleanup
+
+The IP log table grows with every new (user, IP) combination — especially when clients use IPv6 privacy extensions with rotating addresses. To enforce a retention period, delete entries that have not been seen for a given number of days:
+
+``` bash
+vendor/bin/typo3 typo3loginwarning:iplog:cleanup --days 365
+```
+
+Use `--dry-run` to only report how many entries would be deleted. The command is schedulable, e.g. via the TYPO3 scheduler "Execute console commands" task.
+
+> [!NOTE]
+> After an entry has been deleted, the next login from that IP address triggers a new-IP notification again — that is the intended effect of a retention period.
+
 #### Geolocation
 
 If `Fetch Geolocation` is enabled, the extension will use the [ip-api.com](https://ip-api.com/) service to fetch geolocation information for the IP address. Only public IP addresses will be looked up to respect privacy.

--- a/Tests/Unit/Command/CleanupIpLogCommandTest.php
+++ b/Tests/Unit/Command/CleanupIpLogCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_login_warning" TYPO3 CMS extension.
+ *
+ * (c) 2025-2026 Konrad Michalik <km@move-elevator.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MoveElevator\Typo3LoginWarning\Tests\Unit\Command;
+
+use MoveElevator\Typo3LoginWarning\Command\CleanupIpLogCommand;
+use MoveElevator\Typo3LoginWarning\Domain\Repository\IpLogRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function abs;
+use function time;
+
+/**
+ * CleanupIpLogCommandTest.
+ *
+ * @author Konrad Michalik <km@move-elevator.de>
+ * @license GPL-2.0-or-later
+ */
+final class CleanupIpLogCommandTest extends TestCase
+{
+    private IpLogRepository&MockObject $ipLogRepository;
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        $this->ipLogRepository = $this->createMock(IpLogRepository::class);
+        $this->commandTester = new CommandTester(new CleanupIpLogCommand($this->ipLogRepository));
+    }
+
+    public function testDeletesEntriesWithDefaultRetention(): void
+    {
+        $this->ipLogRepository
+            ->expects(self::once())
+            ->method('deleteEntriesLastSeenBefore')
+            ->with(self::callback(
+                static fn (int $threshold): bool => abs($threshold - (time() - 365 * 86400)) < 60,
+            ))
+            ->willReturn(5);
+
+        $exitCode = $this->commandTester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Deleted 5 IP log entries', $this->commandTester->getDisplay());
+    }
+
+    public function testDeletesEntriesWithCustomRetention(): void
+    {
+        $this->ipLogRepository
+            ->expects(self::once())
+            ->method('deleteEntriesLastSeenBefore')
+            ->with(self::callback(
+                static fn (int $threshold): bool => abs($threshold - (time() - 30 * 86400)) < 60,
+            ))
+            ->willReturn(2);
+
+        $exitCode = $this->commandTester->execute(['--days' => '30']);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('more than 30 days', $this->commandTester->getDisplay());
+    }
+
+    public function testDryRunOnlyCountsEntries(): void
+    {
+        $this->ipLogRepository
+            ->expects(self::once())
+            ->method('countEntriesLastSeenBefore')
+            ->with(self::callback(static fn (int $threshold): bool => $threshold < time()))
+            ->willReturn(7);
+
+        $this->ipLogRepository
+            ->expects(self::never())
+            ->method('deleteEntriesLastSeenBefore');
+
+        $exitCode = $this->commandTester->execute(['--dry-run' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('7 IP log entries would be deleted', $this->commandTester->getDisplay());
+    }
+
+    public function testFailsForNonPositiveDays(): void
+    {
+        $this->ipLogRepository
+            ->expects(self::never())
+            ->method('deleteEntriesLastSeenBefore');
+
+        $exitCode = $this->commandTester->execute(['--days' => '0']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('positive integer', $this->commandTester->getDisplay());
+    }
+}

--- a/Tests/Unit/Domain/Repository/IpLogRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/IpLogRepositoryTest.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 namespace MoveElevator\Typo3LoginWarning\Tests\Unit\Domain\Repository;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\Result;
 use MoveElevator\Typo3LoginWarning\Domain\Repository\IpLogRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 
 use function is_int;
 
@@ -30,17 +33,29 @@ use function is_int;
 final class IpLogRepositoryTest extends TestCase
 {
     private Connection&MockObject $connection;
+    private QueryBuilder&MockObject $queryBuilder;
+    private ExpressionBuilder&MockObject $expressionBuilder;
     private IpLogRepository $subject;
 
     protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
+        $this->queryBuilder = $this->createMock(QueryBuilder::class);
+        $this->expressionBuilder = $this->createMock(ExpressionBuilder::class);
 
         $connectionPool = $this->createMock(ConnectionPool::class);
         $connectionPool
             ->method('getConnectionForTable')
             ->with('tx_typo3loginwarning_iplog')
             ->willReturn($this->connection);
+        $connectionPool
+            ->method('getQueryBuilderForTable')
+            ->with('tx_typo3loginwarning_iplog')
+            ->willReturn($this->queryBuilder);
+
+        $this->queryBuilder
+            ->method('expr')
+            ->willReturn($this->expressionBuilder);
 
         $this->subject = new IpLogRepository($connectionPool);
     }

--- a/Tests/Unit/Domain/Repository/IpLogRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/IpLogRepositoryTest.php
@@ -191,4 +191,54 @@ final class IpLogRepositoryTest extends TestCase
 
         $this->subject->addHash($identifierHash);
     }
+
+    public function testCountEntriesLastSeenBefore(): void
+    {
+        $this->queryBuilder->expects(self::once())
+            ->method('count')
+            ->with('uid')
+            ->willReturnSelf();
+        $this->queryBuilder->method('from')->willReturnSelf();
+        $this->queryBuilder->expects(self::once())
+            ->method('createNamedParameter')
+            ->with(12345, Connection::PARAM_INT)
+            ->willReturn(':tstamp');
+        $this->expressionBuilder->method('lt')
+            ->with('tstamp', ':tstamp')
+            ->willReturn('tstamp < :tstamp');
+        $this->queryBuilder->method('where')->willReturnSelf();
+
+        $result = $this->createMock(Result::class);
+        $result->expects(self::once())
+            ->method('fetchOne')
+            ->willReturn('3');
+
+        $this->queryBuilder->expects(self::once())
+            ->method('executeQuery')
+            ->willReturn($result);
+
+        self::assertSame(3, $this->subject->countEntriesLastSeenBefore(12345));
+    }
+
+    public function testDeleteEntriesLastSeenBefore(): void
+    {
+        $this->queryBuilder->expects(self::once())
+            ->method('delete')
+            ->with('tx_typo3loginwarning_iplog')
+            ->willReturnSelf();
+        $this->queryBuilder->expects(self::once())
+            ->method('createNamedParameter')
+            ->with(12345, Connection::PARAM_INT)
+            ->willReturn(':tstamp');
+        $this->expressionBuilder->method('lt')
+            ->with('tstamp', ':tstamp')
+            ->willReturn('tstamp < :tstamp');
+        $this->queryBuilder->method('where')->willReturnSelf();
+
+        $this->queryBuilder->expects(self::once())
+            ->method('executeStatement')
+            ->willReturn(7);
+
+        self::assertSame(7, $this->subject->deleteEntriesLastSeenBefore(12345));
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 		"psr/http-server-handler": "^1.0.2",
 		"psr/http-server-middleware": "^1.0.2",
 		"psr/log": "^3.0.2",
+		"symfony/console": "^6.4 || ^7.0 || ^8.0",
 		"symfony/mailer": "^6.4 || ^7.0 || ^8.0",
 		"symfony/mime": "^6.4 || ^7.0 || ^8.0",
 		"typo3/cms-backend": "^12.0 || ^13.0 || ^14.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "964cb9447ce57bb9cb8339db93f672ee",
+    "content-hash": "45626fcc2a83c7d1eac48394e6d99d59",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -9800,5 +9800,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary

- The `tx_typo3loginwarning_iplog` table grew unbounded — every new (user, IP) combination adds a row and nothing ever deletes them. With IPv6 privacy extensions rotating client addresses this happens continuously, and GDPR-wise the stored (pseudonymized) hashes had no defined retention period.
- New schedulable CLI command `typo3loginwarning:iplog:cleanup` deletes entries whose last sighting (`tstamp`) is older than `--days` (default 365). `--dry-run` reports the count without deleting.
- After cleanup, the next login from a purged IP triggers a new-IP notification again — the intended effect of a retention period.

## Changes

- `Classes/Command/CleanupIpLogCommand.php` - New command (`--days`, `--dry-run`, validation, schedulable)
- `Classes/Domain/Repository/IpLogRepository.php` - `countEntriesLastSeenBefore()` / `deleteEntriesLastSeenBefore()`
- `Configuration/Services.yaml` - `console.command` registration
- `composer.json` / `composer.lock` - Explicit `symfony/console` requirement
- `README.md` - Cleanup section under NewIpDetector
- `Tests/Unit/Command/CleanupIpLogCommandTest.php`, `Tests/Unit/Domain/Repository/IpLogRepositoryTest.php` - Tests for command behavior and both repository methods

## Note

Rows created before #94 keep `tstamp = 0` until they are seen again and are therefore treated as expired by the cleanup — acceptable, since "not seen since insert" is exactly what the retention period targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new console command to clean up old IP log entries.
  * Supports a configurable retention period and a dry-run mode to preview deletions.
  * Can be scheduled automatically.

* **Bug Fixes**
  * Added validation for retention days to prevent invalid cleanup runs.
  * Improved IP log management so outdated entries can be removed safely.

* **Documentation**
  * Updated the README with usage details for the new cleanup command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->