### PR TITLE
chore(ci): run scorecard analysis only on the default branch

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,7 +2,7 @@ name: OpenSSF Scorecard
 on:
   push:
     branches:
-      - '**'
+      - main
   schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- The `ossf/scorecard-action` only supports the repository default branch — on any other branch it aborts with "Only the default branch main is supported". Since the workflow triggered on `push` to `'**'`, every feature-branch push produced a guaranteed-red "scorecard / Scorecard analysis" check on its PR.
- The push trigger is now limited to `main`; the weekly schedule and manual dispatch stay unchanged.

## Changes

- `.github/workflows/scorecard.yml` - Push trigger restricted to `main`