### PR TITLE
test: integrate ttt for PHPUnit test sandboxing

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,8 @@
+# Test fixtures, not real secrets: TYPO3 SYS.encryptionKey values used only in unit tests.
+# Migrating ConfigurationTest to ttt's #[WithTypo3ConfVars] turned the previous
+# $GLOBALS[...]['encryptionKey'] = '...' assignment into an array-arrow literal, which trips
+# gitleaks' generic-api-key rule where the bracket assignment did not. The literals are the
+# obviously-fake string "test-encryption-key-12345"; the HEAD occurrences also carry an inline
+# `gitleaks:allow`, these fingerprints cover the same lines in the historical integration commit.
+f9381041121ecaefabe744efa9b3014d2446277b:Tests/Unit/ConfigurationTest.php:generic-api-key:56
+f9381041121ecaefabe744efa9b3014d2446277b:Tests/Unit/ConfigurationTest.php:generic-api-key:70

--- a/Tests/Unit/Configuration/DetectorConfigurationBuilderTest.php
+++ b/Tests/Unit/Configuration/DetectorConfigurationBuilderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace MoveElevator\Typo3LoginWarning\Tests\Unit\Configuration;
 
 use Exception;
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use MoveElevator\Typo3LoginWarning\Configuration;
 use MoveElevator\Typo3LoginWarning\Configuration\DetectorConfigurationBuilder;
 use MoveElevator\Typo3LoginWarning\Detector\{LongTimeNoSeeDetector, NewIpDetector, OutOfOfficeDetector};
@@ -29,6 +30,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  * @author Konrad Michalik <km@move-elevator.de>
  * @license GPL-2.0-or-later
  */
+#[WithTypo3ConfVars(['EXTENSIONS' => [Configuration::EXT_KEY => []]])]
 final class DetectorConfigurationBuilderTest extends TestCase
 {
     private ExtensionConfiguration&MockObject $extensionConfiguration;
@@ -44,12 +46,6 @@ final class DetectorConfigurationBuilderTest extends TestCase
 
         $this->extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
         $this->subject = new DetectorConfigurationBuilder($this->extensionConfiguration);
-        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY] = [];
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY]);
     }
 
     public function testIsActiveReturnsTrueWhenDetectorIsActive(): void
@@ -189,14 +185,13 @@ final class DetectorConfigurationBuilderTest extends TestCase
         ], $result);
     }
 
+    #[WithTypo3ConfVars(['SYS' => ['phpTimeZone' => 'Europe/Berlin']])]
     public function testBuildOutOfOfficeConfigWithDefaults(): void
     {
         $this->extensionConfiguration
             ->method('get')
             ->with(Configuration::EXT_KEY)
             ->willReturn(['outOfOffice' => ['active' => true]]);
-
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['phpTimeZone'] = 'Europe/Berlin';
 
         $result = $this->subject->build(OutOfOfficeDetector::class);
 
@@ -256,14 +251,13 @@ final class DetectorConfigurationBuilderTest extends TestCase
         ], $result['blockedPeriods']);
     }
 
+    #[WithTypo3ConfVars(['BE' => ['warning_email_addr' => 'admin@example.com']])]
     public function testBuildNotificationConfigWithDefaults(): void
     {
         $this->extensionConfiguration
             ->method('get')
             ->with(Configuration::EXT_KEY)
             ->willReturn([]);
-
-        $GLOBALS['TYPO3_CONF_VARS']['BE']['warning_email_addr'] = 'admin@example.com';
 
         $result = $this->subject->buildNotificationConfig();
 

--- a/Tests/Unit/ConfigurationTest.php
+++ b/Tests/Unit/ConfigurationTest.php
@@ -53,7 +53,7 @@ final class ConfigurationTest extends TestCase
         );
     }
 
-    #[WithTypo3ConfVars(['SYS' => ['encryptionKey' => 'test-encryption-key-12345']])]
+    #[WithTypo3ConfVars(['SYS' => ['encryptionKey' => 'test-encryption-key-12345']])] // gitleaks:allow
     public function testRegisterHmacKeyUsesEncryptionKeyWhenNotSet(): void
     {
         unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['hmacKey']);
@@ -67,7 +67,7 @@ final class ConfigurationTest extends TestCase
     }
 
     #[WithTypo3ConfVars([
-        'SYS' => ['encryptionKey' => 'test-encryption-key-12345'],
+        'SYS' => ['encryptionKey' => 'test-encryption-key-12345'], // gitleaks:allow
         'EXTCONF' => [Configuration::EXT_KEY => ['hmacKey' => 'existing-hmac-key']],
     ])]
     public function testRegisterHmacKeyDoesNotOverwriteExistingKey(): void

--- a/Tests/Unit/ConfigurationTest.php
+++ b/Tests/Unit/ConfigurationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MoveElevator\Typo3LoginWarning\Tests\Unit;
 
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use MoveElevator\Typo3LoginWarning\Configuration;
 use PHPUnit\Framework\TestCase;
 
@@ -22,15 +23,9 @@ use PHPUnit\Framework\TestCase;
  * @author Konrad Michalik <km@move-elevator.de>
  * @license GPL-2.0-or-later
  */
+#[WithTypo3ConfVars([])]
 final class ConfigurationTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        // Clean up global state
-        unset($GLOBALS['TYPO3_CONF_VARS']['MAIL']['templateRootPaths'][500]);
-        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]);
-    }
-
     public function testExtKeyConstant(): void
     {
         self::assertSame('typo3_login_warning', Configuration::EXT_KEY);
@@ -58,9 +53,9 @@ final class ConfigurationTest extends TestCase
         );
     }
 
+    #[WithTypo3ConfVars(['SYS' => ['encryptionKey' => 'test-encryption-key-12345']])]
     public function testRegisterHmacKeyUsesEncryptionKeyWhenNotSet(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'test-encryption-key-12345';
         unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['hmacKey']);
 
         Configuration::registerHmacKey();
@@ -71,11 +66,12 @@ final class ConfigurationTest extends TestCase
         );
     }
 
+    #[WithTypo3ConfVars([
+        'SYS' => ['encryptionKey' => 'test-encryption-key-12345'],
+        'EXTCONF' => [Configuration::EXT_KEY => ['hmacKey' => 'existing-hmac-key']],
+    ])]
     public function testRegisterHmacKeyDoesNotOverwriteExistingKey(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['hmacKey'] = 'existing-hmac-key';
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'test-encryption-key-12345';
-
         Configuration::registerHmacKey();
 
         self::assertSame(

--- a/Tests/Unit/Detector/AbstractDetectorTest.php
+++ b/Tests/Unit/Detector/AbstractDetectorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MoveElevator\Typo3LoginWarning\Tests\Unit\Detector;
 
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use MoveElevator\Typo3LoginWarning\Detector\AbstractDetector;
 use PHPUnit\Framework\TestCase;
 
@@ -52,17 +53,17 @@ final class AbstractDetectorTest extends TestCase
         self::assertFalse($this->subject->exposeShouldDetectForUser($userArray, ['affectedUsers' => 'admins']));
     }
 
+    #[WithTypo3ConfVars(['SYS' => ['systemMaintainers' => [1, 2]]])]
     public function testShouldDetectForUserReturnsTrueForSystemMaintainerWhenAffectedUsersIsMaintainers(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [1, 2];
         $userArray = $this->createUserArray(uid: 1);
 
         self::assertTrue($this->subject->exposeShouldDetectForUser($userArray, ['affectedUsers' => 'maintainers']));
     }
 
+    #[WithTypo3ConfVars(['SYS' => ['systemMaintainers' => [2, 3]]])]
     public function testShouldDetectForUserReturnsFalseForNonSystemMaintainerWhenAffectedUsersIsMaintainers(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [2, 3];
         $userArray = $this->createUserArray(uid: 1);
 
         self::assertFalse($this->subject->exposeShouldDetectForUser($userArray, ['affectedUsers' => 'maintainers']));

--- a/Tests/Unit/Detector/LongTimeNoSeeDetectorTest.php
+++ b/Tests/Unit/Detector/LongTimeNoSeeDetectorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace MoveElevator\Typo3LoginWarning\Tests\Unit\Detector;
 
 use DateTime;
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use MoveElevator\Typo3LoginWarning\Configuration;
 use MoveElevator\Typo3LoginWarning\Detector\{DetectorInterface, LongTimeNoSeeDetector};
 use PHPUnit\Framework\TestCase;
@@ -384,10 +385,9 @@ final class LongTimeNoSeeDetectorTest extends TestCase
         self::assertTrue($result);
     }
 
+    #[WithTypo3ConfVars(['SYS' => ['systemMaintainers' => [2, 3]]])]
     public function testShouldDetectForUserReturnsFalseForNonMaintainer(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [2, 3];
-
         $user = $this->createMockUser(['uid' => 123]);
         $configuration = ['affectedUsers' => 'maintainers'];
 
@@ -396,14 +396,11 @@ final class LongTimeNoSeeDetectorTest extends TestCase
         $result = $subject->shouldDetectForUser($user, $configuration);
 
         self::assertFalse($result);
-
-        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers']);
     }
 
+    #[WithTypo3ConfVars(['SYS' => ['systemMaintainers' => [123, 456]]])]
     public function testShouldDetectForUserReturnsTrueForMaintainer(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [123, 456];
-
         $user = $this->createMockUser(['uid' => 123]);
         $configuration = ['affectedUsers' => 'maintainers'];
 
@@ -412,8 +409,6 @@ final class LongTimeNoSeeDetectorTest extends TestCase
         $result = $subject->shouldDetectForUser($user, $configuration);
 
         self::assertTrue($result);
-
-        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers']);
     }
 
     /**

--- a/Tests/Unit/Detector/NewIpDetectorTest.php
+++ b/Tests/Unit/Detector/NewIpDetectorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MoveElevator\Typo3LoginWarning\Tests\Unit\Detector;
 
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use MoveElevator\Typo3LoginWarning\Detector\{DetectorInterface, NewIpDetector};
 use MoveElevator\Typo3LoginWarning\Domain\Repository\IpLogRepository;
 use MoveElevator\Typo3LoginWarning\Service\GeolocationServiceInterface;
@@ -26,20 +27,18 @@ use RuntimeException;
  * @author Konrad Michalik <km@move-elevator.de>
  * @license GPL-2.0-or-later
  */
+#[WithTypo3ConfVars(['SYS' => ['encryptionKey' => 'test-encryption-key-for-phpunit']])]
 final class NewIpDetectorTest extends TestCase
 {
     protected function setUp(): void
     {
         // Clean slate for each test - set default to avoid issues
         $GLOBALS['_SERVER']['REMOTE_ADDR'] = '127.0.0.1';
-        // Set HMAC key for tests
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'test-encryption-key-for-phpunit';
     }
 
     protected function tearDown(): void
     {
         unset($GLOBALS['_SERVER']['REMOTE_ADDR']);
-        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']);
     }
 
     public function testImplementsDetectorInterface(): void
@@ -288,10 +287,9 @@ final class NewIpDetectorTest extends TestCase
         self::assertTrue($result);
     }
 
+    #[WithTypo3ConfVars(['SYS' => ['systemMaintainers' => [2, 3]]])]
     public function testShouldDetectForUserReturnsFalseForNonMaintainer(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [2, 3];
-
         $user = $this->createMockUser(['uid' => 123]);
         $configuration = ['affectedUsers' => 'maintainers'];
 
@@ -300,14 +298,11 @@ final class NewIpDetectorTest extends TestCase
         $result = $subject->shouldDetectForUser($user, $configuration);
 
         self::assertFalse($result);
-
-        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers']);
     }
 
+    #[WithTypo3ConfVars(['SYS' => ['systemMaintainers' => [123, 456]]])]
     public function testShouldDetectForUserReturnsTrueForMaintainer(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [123, 456];
-
         $user = $this->createMockUser(['uid' => 123]);
         $configuration = ['affectedUsers' => 'maintainers'];
 
@@ -316,8 +311,6 @@ final class NewIpDetectorTest extends TestCase
         $result = $subject->shouldDetectForUser($user, $configuration);
 
         self::assertTrue($result);
-
-        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers']);
     }
 
     public function testDetectAddsDeviceInfoWhenEnabled(): void

--- a/Tests/Unit/Notification/EmailNotificationTest.php
+++ b/Tests/Unit/Notification/EmailNotificationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MoveElevator\Typo3LoginWarning\Tests\Unit\Notification;
 
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use MoveElevator\Typo3LoginWarning\Notification\{EmailNotification, NotifierInterface};
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -29,6 +30,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @author Konrad Michalik <km@move-elevator.de>
  * @license GPL-2.0-or-later
  */
+#[WithTypo3ConfVars(['BE' => ['warning_email_addr' => '']])]
 final class EmailNotificationTest extends TestCase
 {
     private MailerInterface&MockObject $mailer;
@@ -44,9 +46,6 @@ final class EmailNotificationTest extends TestCase
 
         $this->subject = new EmailNotification($this->mailer);
         $this->subject->setLogger($this->logger);
-
-        // Initialize TYPO3_CONF_VARS to prevent warnings
-        $GLOBALS['TYPO3_CONF_VARS']['BE']['warning_email_addr'] = '';
     }
 
     public function testImplementsNotifierInterface(): void
@@ -70,8 +69,6 @@ final class EmailNotificationTest extends TestCase
     {
         $user = $this->createMockBackendUser(['uid' => 123]);
         $configuration = [];
-
-        $GLOBALS['TYPO3_CONF_VARS']['BE']['warning_email_addr'] = '';
 
         $this->logger
             ->expects(self::once())
@@ -101,12 +98,11 @@ final class EmailNotificationTest extends TestCase
         $this->subject->notify($user, $this->request, 'TestTrigger', $configuration);
     }
 
+    #[WithTypo3ConfVars(['BE' => ['warning_email_addr' => 'global@example.com']])]
     public function testNotifyFallsBackToGlobalConfiguration(): void
     {
         $user = $this->createMockBackendUser(['uid' => 123]);
         $configuration = [];
-
-        $GLOBALS['TYPO3_CONF_VARS']['BE']['warning_email_addr'] = 'global@example.com';
 
         $fluidEmail = $this->createMock(FluidEmail::class);
         $fluidEmail->expects(self::once())->method('to')->with('global@example.com')->willReturnSelf();

--- a/Tests/Unit/Security/LoginNotificationTest.php
+++ b/Tests/Unit/Security/LoginNotificationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MoveElevator\Typo3LoginWarning\Tests\Unit\Security;
 
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use MoveElevator\Typo3LoginWarning\Configuration;
 use MoveElevator\Typo3LoginWarning\Configuration\DetectorConfigurationBuilder;
 use MoveElevator\Typo3LoginWarning\Event\ModifyLoginNotificationEvent;
@@ -32,6 +33,10 @@ use TYPO3\CMS\Core\Authentication\Event\AfterUserLoggedInEvent;
  * @author Konrad Michalik <km@move-elevator.de>
  * @license GPL-2.0-or-later
  */
+#[WithTypo3ConfVars([
+    'EXTCONF' => [Configuration::EXT_KEY => ['_notification' => [], '_detector' => []]],
+    'EXTENSIONS' => [Configuration::EXT_KEY => []],
+])]
 final class LoginNotificationTest extends TestCase
 {
     private LoggerInterface&MockObject $logger;
@@ -62,16 +67,6 @@ final class LoginNotificationTest extends TestCase
             $this->eventDispatcher,
         );
         $this->subject->setLogger($this->logger);
-
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['_notification'] = [];
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]['_detector'] = [];
-        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY] = [];
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][Configuration::EXT_KEY]);
-        unset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY]);
     }
 
     public function testWarningAtLoginDoesNothingForNonBackendUsers(): void
@@ -98,18 +93,17 @@ final class LoginNotificationTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    #[WithTypo3ConfVars(['EXTENSIONS' => [Configuration::EXT_KEY => [
+        'newIp' => ['active' => false],
+        'longTimeNoSee' => ['active' => false],
+        'outOfOffice' => ['active' => false],
+    ]]])]
     public function testWarningAtLoginHandlesNoActiveDetectors(): void
     {
         $user = $this->createMock(BackendUserAuthentication::class);
         $user->user = ['uid' => 123];
         $request = $this->createMock(ServerRequestInterface::class);
         $event = new AfterUserLoggedInEvent($user, $request);
-
-        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY] = [
-            'newIp' => ['active' => false],
-            'longTimeNoSee' => ['active' => false],
-            'outOfOffice' => ['active' => false],
-        ];
 
         ($this->subject)($event);
 

--- a/Tests/Unit/Utility/DeviceInfoParserTest.php
+++ b/Tests/Unit/Utility/DeviceInfoParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MoveElevator\Typo3LoginWarning\Tests\Unit\Utility;
 
+use KonradMichalik\Ttt\Attribute\WithTypo3ConfVars;
 use MoveElevator\Typo3LoginWarning\Utility\DeviceInfoParser;
 use PHPUnit\Framework\Attributes\{DataProvider, Test};
 use PHPUnit\Framework\TestCase;
@@ -258,11 +259,9 @@ final class DeviceInfoParserTest extends TestCase
     }
 
     #[Test]
+    #[WithTypo3ConfVars(['SYS' => ['ddmmyy' => 'Y-m-d', 'hhmm' => 'H:i']])]
     public function parseFromRequestIncludesFormattedDate(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] = 'Y-m-d';
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm'] = 'H:i';
-
         $userAgent = 'Mozilla/5.0 (Test) AppleWebKit/537.36';
         $request = $this->createMock(ServerRequestInterface::class);
         $request->method('getHeaderLine')->with('User-Agent')->willReturn($userAgent);

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
 	},
 	"require-dev": {
 		"eliashaeussler/version-bumper": "^2.4 || ^3.0 || ^4.0",
+		"konradmichalik/ttt": "^0.2.0",
 		"mobiledetect/mobiledetectlib": "^4.11.0",
 		"phpunit/phpcov": "^9.0 || ^10.0 || ^11.0 || ^13.0",
 		"phpunit/phpunit": "^10.2 || ^11.0 || ^12.0 || ^13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "964cb9447ce57bb9cb8339db93f672ee",
+    "content-hash": "b815856c93e8a402647869bed4307c3e",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5569,6 +5569,71 @@
             "time": "2026-06-04T05:37:13+00:00"
         },
         {
+            "name": "konradmichalik/ttt",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/konradmichalik/ttt.git",
+                "reference": "7924d932009d8a20b9b4e12e67bf4baf28dd0057"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/konradmichalik/ttt/zipball/7924d932009d8a20b9b4e12e67bf4baf28dd0057",
+                "reference": "7924d932009d8a20b9b4e12e67bf4baf28dd0057",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0 || ^13.0"
+            },
+            "require-dev": {
+                "armin/editorconfig-cli": "^2.0",
+                "ergebnis/composer-normalize": "^2.44",
+                "konradmichalik/php-cs-fixer-preset": "^0.2.0",
+                "konradmichalik/php-doc-block-header-fixer": "^0.3.4",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "rector/rector": "^2.2",
+                "typo3/cms-core": "^13.4 || ^14.0"
+            },
+            "suggest": {
+                "typo3/cms-core": "Required for TYPO3-specific attributes like InApplicationContext and WithEnvironment (^13.4 || ^14.0)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "KonradMichalik\\Ttt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Konrad Michalik",
+                    "email": "hej@konradmichalik.dev",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "ttt - TYPO3 Testing Terrarium. Declarative test sandboxing via PHP attributes: TYPO3_CONF_VARS, application context, environment and more - applied before the test, guaranteed to be restored afterwards.",
+            "keywords": [
+                "Toolbox",
+                "attributes",
+                "php",
+                "phpunit",
+                "sandbox",
+                "testing",
+                "ttt",
+                "typo3"
+            ],
+            "support": {
+                "issues": "https://github.com/konradmichalik/ttt/issues",
+                "source": "https://github.com/konradmichalik/ttt/tree/0.2.0"
+            },
+            "time": "2026-07-27T11:34:34+00:00"
+        },
+        {
             "name": "mobiledetect/mobiledetectlib",
             "version": "4.11.0",
             "source": {
@@ -9800,5 +9865,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,9 @@
          bootstrap="vendor/autoload.php"
          colors="true"
 >
+    <extensions>
+        <bootstrap class="KonradMichalik\Ttt\TttExtension"/>
+    </extensions>
     <php>
         <env name="COLUMNS" value="300" />
     </php>


### PR DESCRIPTION
## Summary

- Integrate [`konradmichalik/ttt`](https://github.com/konradmichalik/ttt) (TYPO3 Testing Terrarium) as the unit-test sandbox, replacing hand-written `TYPO3_CONF_VARS` backup/restore boilerplate with declarative `#[WithTypo3ConfVars]` attributes (guaranteed restore, even on hard failures).
- Register the ttt PHPUnit extension in the unit test configuration only; functional tests are untouched.
- Migrate 8 test classes' `TYPO3_CONF_VARS` juggling to attributes, incidentally fixing several pre-existing state leaks (tests that mutated config without cleanup).

## Changes

- `composer.json` / `composer.lock` - add `konradmichalik/ttt: ^0.2.0` as a dev dependency.
- `phpunit.xml` - register `<bootstrap class="KonradMichalik\Ttt\TttExtension"/>` in the unit test config.
- `Tests/Unit/**` (8 files) - migrate `TYPO3_CONF_VARS` `setUp`/`tearDown` and inline set/unset to `#[WithTypo3ConfVars]` class/method attributes; delete redundant `tearDown` cleanup; keep non-ttt state (`$_SERVER['REMOTE_ADDR']`) as-is.

## Notes

- 264 tests / 750 assertions green before and after; line coverage unchanged at 94.91% (615/648).
- CI matrix is PHP 8.2/8.3/8.4/8.5 (all ≥ 8.2), so ttt's PHP requirement is satisfied — no matrix change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by switching to declarative TYPO3 configuration setup instead of manual runtime global mutations.
  - Updated test scenarios for configuration handling, maintainer checks, notification behavior, and encryption key management.
- **Infrastructure / Tooling**
  - Added PHPUnit bootstrap support to load test configuration attributes.
  - Added test attribute helper dependency.
  - Updated secret scanning ignore rules for test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->